### PR TITLE
Update travis to fix travis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -y
-  - sudo apt-get install -y r-base
+  - sudo apt-get install -y --allow-unauthenticated r-base
   - sudo Rscript -e "install.packages('knitr', repos = 'https://', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('stringr', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('checkpoint', repos = 'https://cran.rstudio.com', dependencies = TRUE)"


### PR DESCRIPTION
Travis CI is throwing an error: https://travis-ci.com/github/datacarpentry/astronomy-python/builds/206641514#L233-L234 because apt-get failed to install packages. Travis throws a relatively uninformative error, but the line above gives more information:

```
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
```

This is my attempt at rectifying the situation. Note that we will be moving away from travis very soon, so this is very much a stopgap
