### PR TITLE
Formatting fixes

### DIFF
--- a/_episodes/01-query.md
+++ b/_episodes/01-query.md
@@ -10,24 +10,18 @@ objectives:
 - "Use queries to explore a database and its tables."
 - "Use queries to download data."
 - "Develop, test, and debug a query incrementally."
+
 keypoints:
 - "If you can't download an entire dataset (or it's not practical) use queries to select the data you need."
-
 - "Read the metadata and the documentation to make sure you understand the tables, their columns, and what they mean."
-
 - "Develop queries incrementally: start with something simple, test it, and add a little bit at a time."
-
 - "Use ADQL features like `TOP` and `COUNT` to test before you run a query that might return a lot of data."
-
 - "If you know your query will return fewer than 3000 rows, you can 
 run it synchronously, which might complete faster (but it doesn't seem to make much difference).  If it might return more than 3000 rows, you should run it asynchronously."
-
 - "ADQL and SQL are not case-sensitive, so you don't have to 
 capitalize the keywords, but you should."
-
 - "ADQL and SQL don't require you to break a query into multiple 
 lines, but you should."
-
 ---
 
 {% include links.md %}
@@ -53,7 +47,6 @@ from the Gaia Database:
 3. We will write a query and send it to the server, and finally
 
 4. We will download the response from the server.
-
 
 ## Query Language
 
@@ -134,8 +127,6 @@ database](https://astroquery.readthedocs.io/en/latest/gaia/gaia.html).
 
 We can connect to the Gaia database like this:
 
-
-
 ~~~
 from astroquery.gaia import Gaia
 ~~~
@@ -152,12 +143,8 @@ Created TAP+ (v1.2.1) - Connection:
 	Use HTTPS: True
 	Port: 443
 	SSL Port: 443
-
 ~~~
 {: .output}
-
-
-    
 
 This import statement creates a
 [TAP+](http://www.ivoa.net/documents/TAP/) connection; TAP stands for
@@ -177,8 +164,6 @@ We can use `Gaia.load_tables` to get the names of the tables in the
 Gaia database.  With the option `only_names=True`, it loads
 information about the tables, called "metadata", not the data itself.
 
-
-
 ~~~
 tables = Gaia.load_tables(only_names=True)
 ~~~
@@ -188,16 +173,10 @@ tables = Gaia.load_tables(only_names=True)
 INFO: Retrieving tables... [astroquery.utils.tap.core]
 INFO: Parsing tables... [astroquery.utils.tap.core]
 INFO: Done. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
 
-
-    
-
 The following `for` loop prints the names of the tables.
-
-
 
 ~~~
 for table in tables:
@@ -221,9 +200,6 @@ external.skymapperdr2_master
 ~~~
 {: .output}
 
-
-    
-
 So that's a lot of tables.  The ones we'll use are:
 
 * `gaiadr2.gaia_source`, which contains Gaia data from [data release
@@ -238,8 +214,6 @@ each star observed by Gaia with the same star observed by PanSTARRS.
 We can use `load_table` (not `load_tables`) to get the metadata for a
 single table.  The name of this function is misleading, because it
 only downloads metadata, not the contents of the table.
-
-
 
 ~~~
 meta = Gaia.load_table('gaiadr2.gaia_source')
@@ -256,22 +230,10 @@ Done.
 ~~~
 {: .output}
 
-
-    
-
-
-
-
-    
-
-
-
 Jupyter shows that the result is an object of type `TapTableMeta`, but
 it does not display the contents.
 
 To see the metadata, we have to print the object.
-
-
 
 ~~~
 print(meta)
@@ -286,18 +248,12 @@ release has been generated. It contains the basic source parameters,
 that is only final data (no epoch data) and no spectra (neither final
 nor epoch).
 Num. columns: 96
-
 ~~~
 {: .output}
-
-
-    
 
 ## Columns
 
 The following loop prints the names of the columns in the table.
-
-
 
 ~~~
 for column in meta.columns:
@@ -320,9 +276,6 @@ parallax_error
 [Output truncated]
 ~~~
 {: .output}
-
-
-    
 
 You can probably infer what many of these columns are by looking at
 the names, but you should resist the temptation to guess.
@@ -365,8 +318,6 @@ database, the query language is a dialect of SQL called ADQL.
 
 Here's an example of an ADQL query.
 
-
-
 ~~~
 query1 = """SELECT 
 TOP 10
@@ -404,8 +355,6 @@ don't affect the behavior of the query.
 To run this query, we use the `Gaia` object, which represents our
 connection to the Gaia database, and invoke `launch_job`:
 
-
-
 ~~~
 job = Gaia.launch_job(query1)
 job
@@ -417,19 +366,9 @@ job
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is an object that represents the job running on a Gaia server.
 
 If you print it, it displays metadata for the forthcoming results.
-
-
 
 ~~~
 print(job)
@@ -452,16 +391,11 @@ Output file: sync_20210315090602.xml.gz
 ~~~
 {: .output}
 
-
-    
-
 Don't worry about `Results: None`.  That does not actually mean there
 are no results.
 
 However, `Phase: COMPLETED` indicates that the job is complete, so we
 can get the results like this:
-
-
 
 ~~~
 results = job.get_results()
@@ -473,14 +407,6 @@ type(results)
 astropy.table.table.Table
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 The `type` function indicates that the result is an [Astropy
 Table](https://docs.astropy.org/en/stable/table/).
@@ -504,8 +430,6 @@ rows.  But these operations use Python syntax, not SQL.
 
 Jupyter knows how to display the contents of a `Table`.
 
-
-
 ~~~
 results
 ~~~
@@ -527,10 +451,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
 <i>Table length=10</i>
 <table id="table139985564118224" class="table-striped table-bordered table-condensed">
 <thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>parallax</th></tr></thead>
@@ -547,8 +467,6 @@ results
 <tr><td>5887982043490374016</td><td>227.985260087594</td><td>-53.683444499055575</td><td>0.02878111976456593</td></tr>
 <tr><td>5887982971205433856</td><td>227.89884570686218</td><td>-53.67430215342567</td><td>--</td></tr>
 </table>
-
-
 
 Each column has a name, units, and a data type.
 
@@ -619,8 +537,6 @@ proper motions along the axes of `ra` and `dec`.
 
 * It uses a new keyword, `WHERE`.
 
-
-
 ~~~
 query2 = """SELECT 
 TOP 3000
@@ -644,8 +560,6 @@ from the database.
 
 We use `launch_job_async` to submit an asynchronous query.
 
-
-
 ~~~
 job = Gaia.launch_job_async(query2)
 job
@@ -659,19 +573,7 @@ INFO: Query finished. [astroquery.utils.tap.core]
 ~~~
 {: .output}
 
-
-    
-
-
-
-
-    
-
-
-
 And here are the results.
-
-
 
 ~~~
 results = job.get_results()
@@ -695,10 +597,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
 <i>Table length=10</i>
 <table id="table139986226873968" class="table-striped table-bordered table-condensed">
 <thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>parallax</th><th>radial_velocity</th></tr></thead>
@@ -715,8 +613,6 @@ results
 <tr><td>5895264899260932352</td><td>213.21521027193236</td><td>-56.78420864489118</td><td>--</td><td>--</td></tr>
 <tr><td>5895265925746051584</td><td>213.17082359534547</td><td>-56.74540885107754</td><td>0.2986918215101751</td><td>--</td></tr>
 </table>
-
-
 
 You might notice that some values of `parallax` are negative.  As
 [this FAQ
@@ -859,8 +755,6 @@ except the column names.
 
 Here's the list of columns we'll select.  
 
-
-
 ~~~
 columns = 'source_id, ra, dec, pmra, pmdec, parallax'
 ~~~
@@ -868,8 +762,6 @@ columns = 'source_id, ra, dec, pmra, pmdec, parallax'
 
 And here's the base; it's a string that contains at least one format
 specifier in curly brackets (braces).
-
-
 
 ~~~
 query3_base = """SELECT 
@@ -888,8 +780,6 @@ placeholder for the list of column names we will provide.
 To assemble the query, we invoke `format` on the base string and
 provide a keyword argument that assigns a value to `columns`.
 
-
-
 ~~~
 query3 = query3_base.format(columns=columns)
 ~~~
@@ -902,8 +792,6 @@ That's not required, but it is a common style.
 The result is a string with line breaks.  If you display it, the line
 breaks appear as `\n`.
 
-
-
 ~~~
 query3
 ~~~
@@ -914,17 +802,7 @@ query3
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 But if you print it, the line breaks appear as... line breaks.
-
-
 
 ~~~
 print(query3)
@@ -938,19 +816,12 @@ source_id, ra, dec, pmra, pmdec
 FROM gaiadr2.gaia_source
 WHERE parallax < 1
   AND bp_rp BETWEEN -0.75 AND 2
-
-
 ~~~
 {: .output}
-
-
-    
 
 Notice that the format specifier has been replaced with the value of `columns`.
 
 Let's run it and see if it works:
-
-
 
 ~~~
 job = Gaia.launch_job(query3)
@@ -974,11 +845,6 @@ Owner: None
 ~~~
 {: .output}
 
-
-    
-
-
-
 ~~~
 results = job.get_results()
 results
@@ -1001,10 +867,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
 <i>Table length=10</i>
 <table id="table139985564118512" class="table-striped table-bordered table-condensed">
 <thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th></tr></thead>
@@ -1021,8 +883,6 @@ results
 <tr><td>4143614130253524096</td><td>269.1749117455479</td><td>-18.53415139972117</td><td>2.6164274510804826</td><td>1.3244248889980894</td></tr>
 <tr><td>4065443904433108992</td><td>273.26868565443743</td><td>-24.421651815402857</td><td>-1.663096652191022</td><td>-2.6514745376067683</td></tr>
 </table>
-
-
 
 Good so far.
 
@@ -1106,10 +966,3 @@ the same variable name in more than one section.
 
 * Keep notebooks short.  Look for places where you can break your
 analysis into phases with one notebook per phase.
-
-
-
-~~~
-
-~~~
-{: .language-python}

--- a/_episodes/01-query.md
+++ b/_episodes/01-query.md
@@ -22,6 +22,10 @@ run it synchronously, which might complete faster (but it doesn't seem to make m
 capitalize the keywords, but you should."
 - "ADQL and SQL don't require you to break a query into multiple 
 lines, but you should."
+- "Make each section of the notebook self-contained.  Try not to use
+the same variable name in more than one section."
+- "Keep notebooks short.  Look for places where you can break your
+analysis into phases with one notebook per phase."
 ---
 
 {% include links.md %}
@@ -930,39 +934,3 @@ This notebook demonstrates the following steps:
 
 In the next lesson we will extend these queries to select a particular
 region of the sky.
-
-## Best practices
-
-* If you can't download an entire dataset (or it's not practical) use
-queries to select the data you need.
-
-* Read the metadata and the documentation to make sure you understand
-the tables, their columns, and what they mean.
-
-* Develop queries incrementally: start with something simple, test it,
-and add a little bit at a time.
-
-* Use ADQL features like `TOP` and `COUNT` to test before you run a
-query that might return a lot of data.
-
-* If you know your query will return fewer than 2000 rows, you can run
-it synchronously, which might complete faster.  If it might return
-more than 2000 rows, you should run it asynchronously.
-
-* ADQL and SQL are not case-sensitive, so you don't have to capitalize
-the keywords, but you should.
-
-* ADQL and SQL don't require you to break a query into multiple lines,
-but you should.
-
-Jupyter notebooks can be good for developing and testing code, but
-they have some drawbacks.  In particular, if you run the cells out of
-order, you might find that variables don't have the values you expect.
-
-To mitigate these problems:
-
-* Make each section of the notebook self-contained.  Try not to use
-the same variable name in more than one section.
-
-* Keep notebooks short.  Look for places where you can break your
-analysis into phases with one notebook per phase.

--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -3,27 +3,18 @@ title: "Coordinate Transformations"
 teaching: 3000
 exercises: 0
 questions:
-
 - "How do we transform celestial coordinates from one frame to another and save results in files?"
 
 objectives:
-
 - "Use Python string formatting to compose more complex ADQL queries."
-
 - "Work with coordinates and other quantities that have units."
-
 - "Download the results of a query and store them in a file."
 
 keypoints:
-
 - "For measurements with units, use `Quantity` objects that represent units explicitly and check for errors."
-
 - "Use the `format` function to compose queries; it is often faster and less error-prone."
-
 - "Develop queries incrementally: start with something simple, test it, and add a little bit at a time."
-
 - "Once you have a query working, save the data in a local file.  If you shut down the notebook and come back to it later, you can reload the file; you don't have to run the query again."
-
 ---
 
 {% include links.md %}
@@ -78,8 +69,6 @@ which makes it possible to detect errors before they cause disasters.
 
 To use Astropy units, we import them like this:
 
-
-
 ~~~
 import astropy.units as u
 ~~~
@@ -89,8 +78,6 @@ import astropy.units as u
 
 You can use `dir` to list them, but you should also [read the
 documentation](https://docs.astropy.org/en/stable/units/).
-
-
 
 ~~~
 dir(u)
@@ -113,17 +100,7 @@ dir(u)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 To create a quantity, we multiply a value by a unit.
-
-
 
 ~~~
 angle = 10 * u.degree
@@ -136,18 +113,8 @@ astropy.units.quantity.Quantity
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is a `Quantity` object.
 Jupyter knows how to display `Quantities` like this:
-
-
 
 ~~~
 angle
@@ -159,18 +126,10 @@ angle
 ~~~
 {: .output}
 
-
-
-
-
 $10 \; \mathrm{^{\circ}}$
-
-
 
 Quantities provide a method called `to` that converts to other units.
 For example, we can compute the number of arcminutes in `angle`:
-
-
 
 ~~~
 angle_arcmin = angle.to(u.arcmin)
@@ -183,17 +142,9 @@ angle_arcmin
 ~~~
 {: .output}
 
-
-
-
-
 $600 \; \mathrm{^{\prime}}$
 
-
-
 If you add quantities, Astropy converts them to compatible units, if possible:
-
-
 
 ~~~
 angle + 30 * u.arcmin
@@ -205,13 +156,7 @@ angle + 30 * u.arcmin
 ~~~
 {: .output}
 
-
-
-
-
 $10.5 \; \mathrm{^{\circ}}$
-
-
 
 If the units are not compatible, you get an error.
 For example:
@@ -219,6 +164,7 @@ For example:
 ```
 angle + 5 * u.second
 ```
+{: .language-python}
 
 causes a `UnitConversionError`.
 
@@ -252,8 +198,6 @@ documentation](https://gea.esac.esa.int/archive-help/adql/examples/index.html)
 that selects objects in a circular region centered at (88.8, 7.4) with
 a search radius of 5 arcmin (0.08333 deg).
 
-
-
 ~~~
 query_cone = """SELECT 
 TOP 10 
@@ -284,8 +228,6 @@ Here is the [documentation of
 A query like this is called a cone search because it selects stars in a cone.
 Here's how we run it.
 
-
-
 ~~~
 from astroquery.gaia import Gaia
 
@@ -310,18 +252,6 @@ Created TAP+ (v1.2.1) - Connection:
 ~~~
 {: .output}
 
-
-    
-
-
-
-
-    
-
-
-
-
-
 ~~~
 results = job.get_results()
 results
@@ -344,10 +274,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
 <i>Table length=10</i>
 <table id="table139807485721280" class="table-striped table-bordered table-condensed">
 <thead><tr><th>source_id</th></tr></thead>
@@ -363,8 +289,6 @@ results
 <tr><td>3322773724537890944</td></tr>
 <tr><td>3322773930696322176</td></tr>
 </table>
-
-
 
 > ## Exercise
 > 
@@ -446,8 +370,6 @@ approximate coordinates of
 "International Celestial Reference System", adopted in 1997 by the
 International Astronomical Union.
 
-
-
 ~~~
 from astropy.coordinates import SkyCoord
 
@@ -465,18 +387,8 @@ coord_icrs
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 `SkyCoord` provides a function that transforms to other frames.
 For example, we can transform `coords_icrs` to Galactic coordinates like this:
-
-
 
 ~~~
 coord_galactic = coord_icrs.transform_to('galactic')
@@ -490,14 +402,6 @@ coord_galactic
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Notice that in the Galactic frame, the coordinates are called `l` and
 `b`, not `ra` and `dec`.
 
@@ -509,8 +413,6 @@ Gala provides
 [`GD1Koposov10`](https://gala-astro.readthedocs.io/en/latest/_modules/gala/coordinates/gd1.html),
 which is "a Heliocentric spherical coordinate system defined by the
 orbit of the GD-1 stream".
-
-
 
 ~~~
 from gala.coordinates import GD1Koposov10
@@ -525,18 +427,8 @@ gd1_frame
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can use it to find the coordinates of Betelgeuse in the GD-1 frame,
 like this:
-
-
 
 ~~~
 coord_gd1 = coord_icrs.transform_to(gd1_frame)
@@ -549,14 +441,6 @@ coord_gd1
     (-94.97222038, 34.5813813)>
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 Notice that the coordinates are called `phi1` and `phi2`.
 These are the coordinates shown in the figure from the paper, above.
@@ -608,8 +492,6 @@ in the GD-1 frame and transform it to ICRS.
 The following variables define the boundaries of the rectangle in
 $\phi_1$ and $\phi_2$.
 
-
-
 ~~~
 phi1_min = -55 * u.degree
 phi1_max = -45 * u.degree
@@ -620,8 +502,6 @@ phi2_max = 4 * u.degree
 
 To create a rectangle, we'll use the following function, which takes
 the lower and upper bounds as parameters.
-
-
 
 ~~~
 def make_rectangle(x1, x2, y1, y2):
@@ -635,8 +515,6 @@ def make_rectangle(x1, x2, y1, y2):
 The return value is a tuple containing a list of coordinates in `phi1`
 followed by a list of coordinates in `phi2`.
 
-
-
 ~~~
 phi1_rect, phi2_rect = make_rectangle(
     phi1_min, phi1_max, phi2_min, phi2_max)
@@ -648,8 +526,6 @@ a rectangle in the GD-1 frame.
 
 In order to use them in a Gaia query, we have to convert them to ICRS.
 First we'll put them into a `SkyCoord` object.
-
-
 
 ~~~
 corners = SkyCoord(phi1=phi1_rect, phi2=phi2_rect, frame=gd1_frame)
@@ -663,17 +539,7 @@ corners
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can use `transform_to` to convert to ICRS coordinates.
-
-
 
 ~~~
 corners_icrs = corners.transform_to('icrs')
@@ -688,14 +554,6 @@ corners_icrs
      (146.27533314, 19.26190982)]>
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 Notice that a rectangle in one coordinate system is not necessarily a
 rectangle in another.  In this example, the result is a
@@ -715,10 +573,9 @@ POLYGON(143.65, 20.98,
         150.16, 29.01)
 """
 ```
+{: .language-python}
 
 `SkyCoord` provides `to_string`, which produces a list of strings.
-
-
 
 ~~~
 t = corners_icrs.to_string()
@@ -735,18 +592,8 @@ t
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can use the Python string function `join` to join `t` into a single
 string (with spaces between the pairs):
-
-
 
 ~~~
 s = ' '.join(t)
@@ -759,17 +606,7 @@ s
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 That's almost what we need, but we have to replace the spaces with commas.
-
-
 
 ~~~
 s.replace(' ', ', ')
@@ -781,17 +618,7 @@ s.replace(' ', ', ')
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The following function combines these steps.
-
-
 
 ~~~
 def skycoord_to_string(skycoord):
@@ -804,8 +631,6 @@ def skycoord_to_string(skycoord):
 
 Here's how we use it.
 
-
-
 ~~~
 point_list = skycoord_to_string(corners_icrs)
 point_list
@@ -817,20 +642,10 @@ point_list
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 ## Assembling the query
 
 Now we're ready to assemble the query. 
 We need `columns` again (as we saw in the previous lesson).
-
-
 
 ~~~
 columns = 'source_id, ra, dec, pmra, pmdec, parallax'
@@ -838,8 +653,6 @@ columns = 'source_id, ra, dec, pmra, pmdec, parallax'
 {: .language-python}
 
 And here's the query base we used in the previous lesson:
-
-
 
 ~~~
 query3_base = """SELECT 
@@ -853,8 +666,6 @@ WHERE parallax < 1
 {: .language-python}
 
 Now we'll add a `WHERE` clause to select stars in the polygon we defined.
-
-
 
 ~~~
 query4_base = """SELECT
@@ -872,8 +683,6 @@ WHERE parallax < 1
 The query base contains format specifiers for `columns` and `point_list`.
 
 We'll use `format` to fill in these values.
-
-
 
 ~~~
 query4 = query4_base.format(columns=columns, 
@@ -894,14 +703,9 @@ WHERE parallax < 1
 
 
 ~~~
-{: .output}
-
-
-    
+{: .output}    
 
 As always, we should take a minute to proof-read the query before we launch it.
-
-
 
 ~~~
 job = Gaia.launch_job_async(query4)
@@ -925,12 +729,7 @@ Phase: COMPLETED
 ~~~
 {: .output}
 
-
-    
-
 Here are the results.
-
-
 
 ~~~
 results = job.get_results()
@@ -954,10 +753,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
 <i>Table length=10</i>
 <table id="table139807251332016" class="table-striped table-bordered table-condensed">
 <thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th></tr></thead>
@@ -975,13 +770,9 @@ results
 <tr><td>637973067758974208</td><td>142.89551292869012</td><td>21.612824100339875</td><td>-8.645166256559063</td><td>-44.41164172204947</td></tr>
 </table>
 
-
-
 Finally, we can remove `TOP 10` run the query again.
 
 The result is bigger than our previous queries, so it will take a little longer.
-
-
 
 ~~~
 query5_base = """SELECT
@@ -994,8 +785,6 @@ WHERE parallax < 1
 """
 ~~~
 {: .language-python}
-
-
 
 ~~~
 query5 = query5_base.format(columns=columns, 
@@ -1012,15 +801,8 @@ WHERE parallax < 1
   AND bp_rp BETWEEN -0.75 AND 2 
   AND 1 = CONTAINS(POINT(ra, dec), 
                    POLYGON(146.275, 19.2619, 135.422, 25.8774, 141.603, 34.3048, 152.817, 27.1361, 146.275, 19.2619))
-
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 job = Gaia.launch_job_async(query5)
@@ -1044,11 +826,6 @@ Phase: COMPLETED
 ~~~
 {: .output}
 
-
-    
-
-
-
 ~~~
 results = job.get_results()
 len(results)
@@ -1059,14 +836,6 @@ len(results)
 140339
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 There are more than 100,000 stars in this polygon, but that's a
 manageable size to work with.
@@ -1080,8 +849,6 @@ Storing the data in a file means we can shut down this notebook and
 pick up where we left off without running the previous query again.
 
 Astropy `Table` objects provide `write`, which writes the table to disk.
-
-
 
 ~~~
 filename = 'gd1_results.fits'
@@ -1098,8 +865,6 @@ overwritten.
 
 We can use `getsize` to confirm that the file exists and check the size:
 
-
-
 ~~~
 from os.path import getsize
 
@@ -1112,14 +877,6 @@ getsize(filename) / MB
 5.36407470703125
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 ## Summary
 

--- a/_episodes/03-motion.md
+++ b/_episodes/03-motion.md
@@ -4,31 +4,20 @@ teaching: 3000
 exercises: 0
 
 questions:
-
 - "How do we make scatter plots in Matplotlib? How do we store data in a Pandas `DataFrame`?"
 
 objectives:
-
 - "Select rows and columns from an Astropy `Table`."
-
 - "Use Matplotlib to make a scatter plot."
-
 - "Use Gala to transform coordinates."
-
 - "Make a Pandas `DataFrame` and use a Boolean `Series` to select rows."
-
 - "Save a `DataFrame` in an HDF5 file."
 
 keypoints:
-
 - "When you make a scatter plot, adjust the size of the markers and their transparency so the figure is not overplotted; otherwise it can misrepresent the data badly."
-
 - "For simple scatter plots in Matplotlib, `plot` is faster than `scatter`."
-
 - "An Astropy `Table` and a Pandas `DataFrame` are similar in many ways and they provide many of the same functions.  They have pros and cons, but for many projects, either one would be a reasonable choice."
-
 - "To store data from a Pandas `DataFrame`, a good option is an HDF file, which can contain multiple Datasets."
-
 ---
 
 {% include links.md %}
@@ -73,7 +62,6 @@ After completing this lesson, you should be able to
 
 * Save a `DataFrame` in an HDF5 file.
 
-
 ## Reload the data
 
 In the previous lesson, we ran a query on the Gaia server and
@@ -87,8 +75,6 @@ file called `gd1_results.fits` that contains the data we downloaded.
 If not, you can [download the
 file](https://github.com/AllenDowney/AstronomicalData/raw/main/data/gd1_results.fits)
 or run the following cell.
-
-
 
 ~~~
 from os.path import basename, exists
@@ -107,8 +93,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 
 Now here's how we can read the data from the file back into an Astropy `Table`:
 
-
-
 ~~~
 from astropy.table import Table
 
@@ -120,8 +104,6 @@ results = Table.read(filename)
 The result is an Astropy `Table`.
 
 We can use `info` to refresh our memory of the contents.
-
-
 
 ~~~
 results.info
@@ -141,14 +123,6 @@ source_id   int64          Unique source identifier (unique within a particular 
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 ## Selecting rows and columns
 
 In this section we'll see operations for selecting columns and rows
@@ -157,8 +131,6 @@ operations in the [Astropy
 documentation](https://docs.astropy.org/en/stable/table/access_table.html).
 
 We can get the names of the columns like this:
-
-
 
 ~~~
 results.colnames
@@ -170,17 +142,7 @@ results.colnames
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And select an individual column like this:
-
-
 
 ~~~
 results['ra']
@@ -202,10 +164,6 @@ results['ra']
 [Output truncated]
 ~~~
 {: .output}
-
-
-
-
 
 &lt;Column name=&apos;ra&apos; dtype=&apos;float64&apos; unit=&apos;deg&apos; description=&apos;Right ascension&apos; length=140339&gt;
 <table>
@@ -236,12 +194,8 @@ results['ra']
 <tr><td>143.7702681295401</td></tr>
 </table>
 
-
-
 The result is a `Column` object that contains the data, and also the
 data type, units, and name of the column.
-
-
 
 ~~~
 type(results['ra'])
@@ -253,18 +207,8 @@ astropy.table.column.Column
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The rows in the `Table` are numbered from 0 to `n-1`, where `n` is the
 number of rows.  We can select the first row like this:
-
-
 
 ~~~
 results[0]
@@ -281,10 +225,6 @@ results[0]
 ~~~
 {: .output}
 
-
-
-
-
 <i>Row index=0</i>
 <table id="table139673160217120">
 <thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th><th>parallax</th></tr></thead>
@@ -293,11 +233,7 @@ results[0]
 <tr><td>637987125186749568</td><td>142.48301935991023</td><td>21.75771616932985</td><td>-2.5168384683875766</td><td>2.941813096629439</td><td>-0.2573448962333354</td></tr>
 </table>
 
-
-
 As you might have guessed, the result is a `Row` object.
-
-
 
 ~~~
 type(results[0])
@@ -309,14 +245,6 @@ astropy.table.row.Row
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Notice that the bracket operator selects both columns and rows.  You
 might wonder how it knows which to select.
 If the expression in brackets is a string, it selects a column; if the
@@ -324,8 +252,6 @@ expression is an integer, it selects a row.
 
 If you apply the bracket operator twice, you can select a column and
 then an element from the column.
-
-
 
 ~~~
 results['ra'][0]
@@ -337,17 +263,7 @@ results['ra'][0]
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Or you can select a row and then an element from the row.
-
-
 
 ~~~
 results[0]['ra']
@@ -358,14 +274,6 @@ results[0]['ra']
 142.48301935991023
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 You get the same result either way.
 
@@ -379,8 +287,6 @@ you know MATLAB, some of it will be familiar.
 
 We'll import like this.
 
-
-
 ~~~
 import matplotlib.pyplot as plt
 ~~~
@@ -389,16 +295,18 @@ import matplotlib.pyplot as plt
 Pyplot is part of the Matplotlib library.  It is conventional to
 import it using the shortened name `plt`.
 
-In recent versions of Jupyter, plots appear "inline"; that is, they
-are part of the notebook.  In some older versions, plots appear in a
-new window.
-In that case, you might want to run the following Jupyter [magic
-command](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib)
-in a notebook cell:
-
-```
-%matplotlib inline
-```
+> ## Warning
+> In recent versions of Jupyter, plots appear "inline"; that is, they
+> are part of the notebook.  In some older versions, plots appear in a
+> new window.
+> In that case, you might want to run the following Jupyter
+> [magic command](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-matplotlib)
+> in a notebook cell:
+> ~~~
+> %matplotlib inline
+> ~~~
+> {: .language-python}
+{: .callout}
 
 Pyplot provides two functions that can make scatterplots,
 [plt.scatter](https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.scatter.html)
@@ -420,8 +328,6 @@ same size and color, we'll use `plot`.
 Here's a scatter plot with right ascension on the x-axis and
 declination on the y-axis, both ICRS coordinates in degrees.
 
-
-
 ~~~
 x = results['ra']
 y = results['dec']
@@ -436,14 +342,9 @@ plt.ylabel('dec (degree ICRS)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](03-motion_files/03-motion_28_0.png)
     
-
-
 The arguments to `plt.plot` are `x`, `y`, and a string that specifies
 the style.  In this case, the letters `ko` indicate that we want a
 black, round marker (`k` is for black because `b` is for blue).
@@ -482,14 +383,14 @@ transparency of the points.
 > > ## Solution
 > > 
 > > ~~~
+> > x = results['ra']
+> > y = results['dec']
+> > plt.plot(x, y, 'ko', markersize=0.1, alpha=0.1)
 > > 
-> > # x = results['ra']
-> > # y = results['dec']
-> > # plt.plot(x, y, 'ko', markersize=0.1, alpha=0.1)
-> > 
-> > # plt.xlabel('ra (degree ICRS)')
-> > # plt.ylabel('dec (degree ICRS)');
+> > plt.xlabel('ra (degree ICRS)')
+> > plt.ylabel('dec (degree ICRS)');
 > > ~~~
+> > 
 > > {: .language-python}
 > {: .solution}
 {: .challenge}
@@ -516,8 +417,6 @@ To do the transformation, we'll put the results into a `SkyCoord`
 object.  In a previous lesson we created a `SkyCoord` object like
 this:
 
-
-
 ~~~
 from astropy.coordinates import SkyCoord
 
@@ -531,8 +430,6 @@ Now we're going to do something similar, but in addition to `ra` and
 * `pmra` and `pmdec`, which are proper motion in the ICRS frame, and
 
 * `distance` and `radial_velocity`, which we explain below.
-
-
 
 ~~~
 import astropy.units as u
@@ -555,8 +452,6 @@ For `distance` and `radial_velocity` we use constants, which we explain below.
 
 The result is an Astropy `SkyCoord` object, which we can transform to
 the GD-1 frame.
-
-
 
 ~~~
 from gala.coordinates import GD1Koposov10
@@ -599,8 +494,6 @@ With this preparation, we can use `reflex_correct` from Gala
 here](https://gala-astro.readthedocs.io/en/latest/api/gala.coordinates.reflex_correct.html))
 to correct for the motion of the solar system.
 
-
-
 ~~~
 from gala.coordinates import reflex_correct
 
@@ -618,8 +511,6 @@ corrected proper motions.
 
 We can select the coordinates and plot them like this:
 
-
-
 ~~~
 x = skycoord_gd1.phi1
 y = skycoord_gd1.phi2
@@ -634,13 +525,8 @@ plt.ylabel('phi2 (degree GD1)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](03-motion_files/03-motion_43_0.png)
-    
-
 
 Remember that we started with a rectangle in the GD-1 frame.  When
 transformed to the ICRS frame, it's a non-rectangular region.  Now,
@@ -650,8 +536,6 @@ transformed back to the GD-1 frame, it's a rectangle again.
 
 At this point we have two objects containing different subsets of the
 data.  `results` is the Astropy `Table` we downloaded from Gaia.
-
-
 
 ~~~
 type(results)
@@ -663,18 +547,8 @@ astropy.table.table.Table
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And `skycoord_gd1` is a `SkyCoord` object that contains the
 transformed coordinates and proper motions.
-
-
 
 ~~~
 type(skycoord_gd1)
@@ -685,14 +559,6 @@ type(skycoord_gd1)
 astropy.coordinates.sky_coordinate.SkyCoord
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 On one hand, this division of labor makes sense because each object
 provides different capabilities.  But working with multiple object
@@ -714,8 +580,6 @@ units for the columns.
 
 It's easy to convert a `Table` to a Pandas `DataFrame`.
 
-
-
 ~~~
 import pandas as pd
 
@@ -724,8 +588,6 @@ results_df = results.to_pandas()
 {: .language-python}
 
 `DataFrame` provides `shape`, which shows the number of rows and columns.
-
-
 
 ~~~
 results_df.shape
@@ -737,18 +599,8 @@ results_df.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 It also provides `head`, which displays the first few rows.  `head` is
 useful for spot-checking large results as you go along.
-
-
 
 ~~~
 results_df.head()
@@ -764,10 +616,6 @@ results_df.head()
 4  638049655615392384  142.589136  22.110783   0.244439  -4.941079  0.099625
 ~~~
 {: .output}
-
-
-
-
 
 <div>
 <style scoped>
@@ -845,8 +693,6 @@ results_df.head()
 </table>
 </div>
 
-
-
 **Python detail:** `shape` is an attribute, so we display its value
 without calling it as a function; `head` is a function, so we need the
 parentheses.
@@ -854,8 +700,6 @@ parentheses.
 Now we can extract the columns we want from `skycoord_gd1` and add
 them as columns in the `DataFrame`.  `phi1` and `phi2` contain the
 transformed coordinates.
-
-
 
 ~~~
 results_df['phi1'] = skycoord_gd1.phi1
@@ -869,18 +713,8 @@ results_df.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 `pm_phi1_cosphi2` and `pm_phi2` contain the components of proper
 motion in the transformed frame.
-
-
 
 ~~~
 results_df['pm_phi1'] = skycoord_gd1.pm_phi1_cosphi2
@@ -894,14 +728,6 @@ results_df.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 **Detail:** If you notice that `SkyCoord` has an attribute called
 `proper_motion`, you might wonder why we are not using it.
 
@@ -914,8 +740,6 @@ One benefit of using Pandas is that it provides functions for
 exploring the data and checking for problems.
 One of the most useful of these functions is `describe`, which
 computes summary statistics for each column.
-
-
 
 ~~~
 results_df.describe()
@@ -937,10 +761,6 @@ max    7.974418e+17     152.777393      34.285481     104.319923
 [Output truncated]
 ~~~
 {: .output}
-
-
-
-
 
 <div>
 <style scoped>
@@ -1081,8 +901,6 @@ max    7.974418e+17     152.777393      34.285481     104.319923
 </table>
 </div>
 
-
-
 > ## Exercise
 > 
 > Review the summary statistics in this table.
@@ -1092,21 +910,16 @@ max    7.974418e+17     152.777393      34.285481     104.319923
 > * Do you see any values that seem problematic, or evidence of other data issues?
 >
 > > ## Solution
+> >
+> > The most noticeable issue is that some of the
+> > parallax values are negative, which is non-physical.
 > > 
-> > ~~~
+> > The reason is that parallax measurements are less accurate
+> > for stars that are far away.
 > > 
-> > # The most noticeable issue is that some of the
-> > # parallax values are negative, which is non-physical.
-> > 
-> > # The reason is that parallax measurements are less accurate
-> > # for stars that are far away.
-> > 
-> > # Fortunately, we don't use the parallax measurements in
-> > # the analysis (one of the reasons we used constant distance
-> > # for reflex correction).
-> > 
-> > ~~~
-> > {: .language-python}
+> > Fortunately, we don't use the parallax measurements in
+> > the analysis (one of the reasons we used constant distance
+> > for reflex correction).
 > {: .solution}
 {: .challenge}
 
@@ -1137,8 +950,6 @@ more likely to be in GD-1.
 The following figure is a scatter plot of proper motion, in the GD-1
 frame, for the stars in `results_df`.
 
-
-
 ~~~
 x = results_df['pm_phi1']
 y = results_df['pm_phi2']
@@ -1153,20 +964,13 @@ plt.ylabel('Proper motion phi2 (mas/yr GD1 frame)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+ 
 ![png](03-motion_files/03-motion_67_0.png)
-    
-
 
 Most of the proper motions are near the origin, but there are a few
 extreme values.
 Following the example in the paper, we'll use `xlim` and `ylim` to
 zoom in on the region near the origin.
-
-
 
 ~~~
 x = results_df['pm_phi1']
@@ -1185,13 +989,8 @@ plt.ylim(-10, 10);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](03-motion_files/03-motion_69_0.png)
-    
-
 
 There is a hint of an overdense region near (-7.5, 0), but if you
 didn't know where to look, you would miss it.
@@ -1213,8 +1012,6 @@ Stars near this line have the highest probability of being in GD-1.
 To select them, we will use a "Boolean mask".  We'll start by
 selecting the `phi2` column from the `DataFrame`:
 
-
-
 ~~~
 phi2 = results_df['phi2']
 type(phi2)
@@ -1226,21 +1023,11 @@ pandas.core.series.Series
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is a `Series`, which is the structure Pandas uses to
 represent columns.
 
 We can use a comparison operator, `>`, to compare the values in a
 `Series` to a constant.
-
-
 
 ~~~
 phi2_min = -1.0 * u.degree
@@ -1256,17 +1043,7 @@ pandas.core.series.Series
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is a `Series` of Boolean values, that is, `True` and `False`. 
-
-
 
 ~~~
 mask.head()
@@ -1283,19 +1060,9 @@ Name: phi2, dtype: bool
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 To select values that fall between `phi2_min` and `phi2_max`, we'll
 use the `&` operator, which computes "logical AND".
 The result is true where elements from both Boolean `Series` are true.
-
-
 
 ~~~
 mask = (phi2 > phi2_min) & (phi2 < phi2_max)
@@ -1314,8 +1081,6 @@ order of operations is incorrect.
 The sum of a Boolean `Series` is the number of `True` values, so we
 can use `sum` to see how many stars are in the selected region.
 
-
-
 ~~~
 mask.sum()
 ~~~
@@ -1326,19 +1091,9 @@ mask.sum()
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 A Boolean `Series` is sometimes called a "mask" because we can use it
 to mask out some of the rows in a `DataFrame` and select the rest,
 like this:
-
-
 
 ~~~
 centerline_df = results_df[mask]
@@ -1351,21 +1106,11 @@ pandas.core.frame.DataFrame
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 `centerline_df` is a `DataFrame` that contains only the rows from
 `results_df` that correspond to `True` values in `mask`.
 So it contains the stars near the centerline of GD-1.
 
 We can use `len` to see how many rows are in `centerline_df`:
-
-
 
 ~~~
 len(centerline_df)
@@ -1377,17 +1122,7 @@ len(centerline_df)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And what fraction of the rows we've selected.
-
-
 
 ~~~
 len(centerline_df) / len(results_df)
@@ -1399,22 +1134,12 @@ len(centerline_df) / len(results_df)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 There are about 25,000 stars in this region, about 18% of the total.
 
 ## Plotting proper motion
 
 Since we've plotted proper motion several times, let's put that code
 in a function.
-
-
 
 ~~~
 def plot_proper_motion(df):
@@ -1436,8 +1161,6 @@ def plot_proper_motion(df):
 
 And we can call it like this:
 
-
-
 ~~~
 plot_proper_motion(centerline_df)
 ~~~
@@ -1447,13 +1170,8 @@ plot_proper_motion(centerline_df)
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](03-motion_files/03-motion_92_0.png)
-    
-
 
 Now we can see more clearly that there is a cluster near (-7.5, 0).
 
@@ -1482,8 +1200,6 @@ how to select a polygonal region as well.
 
 Here are bounds on proper motion we chose by eye:
 
-
-
 ~~~
 pm1_min = -8.9
 pm1_max = -6.9
@@ -1495,8 +1211,6 @@ pm2_max =  1.0
 To draw these bounds, we'll use `make_rectangle` to make two lists
 containing the coordinates of the corners of the rectangle.
 
-
-
 ~~~
 def make_rectangle(x1, x2, y1, y2):
     """Return the corners of a rectangle."""
@@ -1506,8 +1220,6 @@ def make_rectangle(x1, x2, y1, y2):
 ~~~
 {: .language-python}
 
-
-
 ~~~
 pm1_rect, pm2_rect = make_rectangle(
     pm1_min, pm1_max, pm2_min, pm2_max)
@@ -1515,8 +1227,6 @@ pm1_rect, pm2_rect = make_rectangle(
 {: .language-python}
 
 Here's what the plot looks like with the bounds we chose.
-
-
 
 ~~~
 plot_proper_motion(centerline_df)
@@ -1528,13 +1238,8 @@ plt.plot(pm1_rect, pm2_rect, '-');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](03-motion_files/03-motion_100_0.png)
-    
-
 
 Now that we've identified the bounds of the cluster in proper motion,
 we'll use it to select rows from `results_df`.
@@ -1542,8 +1247,6 @@ we'll use it to select rows from `results_df`.
 We'll use the following function, which uses Pandas operators to make
 a mask that selects rows where `series` falls between `low` and
 `high`.
-
-
 
 ~~~
 def between(series, low, high):
@@ -1553,8 +1256,6 @@ def between(series, low, high):
 {: .language-python}
 
 The following mask selects stars with proper motion in the region we chose.
-
-
 
 ~~~
 pm1 = results_df['pm_phi1']
@@ -1567,8 +1268,6 @@ pm_mask = (between(pm1, pm1_min, pm1_max) &
 
 Again, the sum of a Boolean series is the number of `True` values.
 
-
-
 ~~~
 pm_mask.sum()
 ~~~
@@ -1579,17 +1278,7 @@ pm_mask.sum()
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can use this mask to select rows from `results_df`.
-
-
 
 ~~~
 selected_df = results_df[pm_mask]
@@ -1602,18 +1291,8 @@ len(selected_df)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 These are the stars we think are likely to be in GD-1.  Let's see what
 they look like, plotting their coordinates (not their proper motion).
-
-
 
 ~~~
 x = selected_df['phi1']
@@ -1629,13 +1308,8 @@ plt.ylabel('phi2 (degree GD1)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](03-motion_files/03-motion_110_0.png)
-    
-
 
 Now that's starting to look like a tidal stream!
 
@@ -1647,8 +1321,6 @@ results; this is a good time to save the data.
 To save a Pandas `DataFrame`, one option is to convert it to an
 Astropy `Table`, like this:
 
-
-
 ~~~
 selected_table = Table.from_pandas(selected_df)
 type(selected_table)
@@ -1659,14 +1331,6 @@ type(selected_table)
 astropy.table.table.Table
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 Then we could write the `Table` to a FITS file, as we did in the
 previous lesson.
@@ -1696,8 +1360,6 @@ file with Pandas, you can read it back with many other software tools
 
 We can write a Pandas `DataFrame` to an HDF5 file like this:
 
-
-
 ~~~
 filename = 'gd1_data.hdf'
 
@@ -1724,16 +1386,14 @@ should overwrite it.
 > > ## Solution
 > > 
 > > ~~~
-> > 
 > > centerline_df.to_hdf(filename, 'centerline_df')
 > > ~~~
+> > 
 > > {: .language-python}
 > {: .solution}
 {: .challenge}
 
 We can use `getsize` to confirm that the file exists and check the size:
-
-
 
 ~~~
 from os.path import getsize
@@ -1748,18 +1408,8 @@ getsize(filename) / MB
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 If you forget what the names of the Datasets in the file are, you can
 read them back like this:
-
-
 
 ~~~
 with pd.HDFStore(filename) as hdf:
@@ -1769,17 +1419,14 @@ with pd.HDFStore(filename) as hdf:
 
 ~~~
 ['/centerline_df', '/selected_df']
-
 ~~~
 {: .output}
 
-
-    
-
-**Python note:** We use a `with` statement here to open the file
-before the print statement and (automatically) close it after.  Read
-more about [context
-managers](https://book.pythontips.com/en/latest/context_managers.html).
+> ## Context Managers
+> We use a `with` statement here to open the file
+> before the print statement and (automatically) close it after.  Read
+> more about [context managers](https://book.pythontips.com/en/latest/context_managers.html).
+{: .callout}
 
 The keys are the names of the Datasets.  Notice that they start with
 `/`, which indicates that they are at the top level of the Dataset
@@ -1810,25 +1457,3 @@ motion is in that region.
 So far, we have used data from a relatively small region of the sky.
 In the next lesson, we'll write a query that selects stars based on
 proper motion, which will allow us to explore a larger region.
-
-## Best practices
-
-* When you make a scatter plot, adjust the size of the markers and
-their transparency so the figure is not overplotted; otherwise it can
-misrepresent the data badly.
-
-* For simple scatter plots in Matplotlib, `plot` is faster than `scatter`.
-
-* An Astropy `Table` and a Pandas `DataFrame` are similar in many ways
-and they provide many of the same functions.  They have pros and cons,
-but for many projects, either one would be a reasonable choice.
-
-* To store data from a Pandas `DataFrame`, a good option is an HDF
-file, which can contain multiple Datasets.
-
-
-
-~~~
-
-~~~
-{: .language-python}

--- a/_episodes/04-select.md
+++ b/_episodes/04-select.md
@@ -3,27 +3,18 @@ title: "Transform and Select"
 teaching: 3000
 exercises: 0
 questions:
-
 - "How do we move the computation to the data?"
 
 objectives:
-
 - "Transform proper motions from one frame to another."
-
 - "Compute the convex hull of a set of points."
-
 - "Write an ADQL query that selects based on proper motion."
-
 - "Save data in CSV format."
 
 keypoints:
-
 - "When possible, 'move the computation to the data'; that is, do as much of the work as possible on the database server before downloading the data."
-
 - "For most applications, saving data in FITS or HDF5 is better than CSV.  FITS and HDF5 are binary formats, so the files are usually smaller, and they store metadata, so you don't lose anything when you read the file back."
-
 - "On the other hand, CSV is a 'least common denominator' format; that is, it can be read by practically any application that works with data."
-
 ---
 
 {% include links.md %}
@@ -67,8 +58,6 @@ You can [download the data from the previous
 lesson](https://github.com/AllenDowney/AstronomicalData/raw/main/data/gd1_data.hdf)
 or run the following cell, which downloads it if necessary.
 
-
-
 ~~~
 from os.path import basename, exists
 
@@ -85,8 +74,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 {: .language-python}
 
 Now we can reload `centerline_df` and `selected_df`.
-
-
 
 ~~~
 import pandas as pd
@@ -128,8 +115,6 @@ have to work with proper motions in ICRS.
 As a reminder, here's the rectangle we selected based on proper motion
 in the `GD1Koposov10` frame.
 
-
-
 ~~~
 pm1_min = -8.9
 pm1_max = -6.9
@@ -137,8 +122,6 @@ pm2_min = -2.2
 pm2_max =  1.0
 ~~~
 {: .language-python}
-
-
 
 ~~~
 def make_rectangle(x1, x2, y1, y2):
@@ -149,8 +132,6 @@ def make_rectangle(x1, x2, y1, y2):
 ~~~
 {: .language-python}
 
-
-
 ~~~
 pm1_rect, pm2_rect = make_rectangle(
     pm1_min, pm1_max, pm2_min, pm2_max)
@@ -159,8 +140,6 @@ pm1_rect, pm2_rect = make_rectangle(
 
 Since we'll need to plot proper motion several times, we'll use the
 following function.
-
-
 
 ~~~
 import matplotlib.pyplot as plt
@@ -190,8 +169,6 @@ The following figure shows:
 
 * The stars inside the rectangle highlighted in green.
 
-
-
 ~~~
 plot_proper_motion(centerline_df)
 
@@ -207,18 +184,11 @@ plt.plot(x, y, 'gx', markersize=0.3, alpha=0.3);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+ 
 ![png](04-select_files/04-select_14_0.png)
-    
-
 
 Now we'll make the same plot using proper motions in the ICRS frame,
 which are stored in columns `pmra` and `pmdec`.
-
-
 
 ~~~
 x = centerline_df['pmra']
@@ -241,13 +211,8 @@ plt.ylim([-20, 5]);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+  
 ![png](04-select_files/04-select_16_0.png)
-    
-
 
 The proper motions of the selected stars are more spread out in this
 frame, which is why it was preferable to do the selection in the GD-1
@@ -266,8 +231,6 @@ which is the smallest convex polygon that contains all of the points.
 To use it, we'll select columns `pmra` and `pmdec` and convert them to
 a NumPy array.
 
-
-
 ~~~
 import numpy as np
 
@@ -281,26 +244,18 @@ points.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
-NOTE: If you are using an older version of Pandas, you might not have
-`to_numpy()`; you can use `values` instead, like this:
-
-```
-points = selected_df[['pmra','pmdec']].values
-
-```
+> ## Note
+> If you are using an older version of Pandas, you might not have
+> `to_numpy()`; you can use `values` instead, like this:
+> 
+> ~~~
+> points = selected_df[['pmra','pmdec']].values
+> ~~~
+> {: .language-python}
+{: .callout}
 
 We'll pass the points to `ConvexHull`, which returns an object that
 contains the results.
-
-
 
 ~~~
 from scipy.spatial import ConvexHull
@@ -315,18 +270,8 @@ hull
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 `hull.vertices` contains the indices of the points that fall on the
 perimeter of the hull.
-
-
 
 ~~~
 hull.vertices
@@ -339,18 +284,8 @@ array([ 692,  873,  141,  303,   42,  622,   45,   83,  127,  182, 1006,
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can use them as an index into the original array to select the
 corresponding rows.
-
-
 
 ~~~
 pm_vertices = points[hull.vertices]
@@ -374,17 +309,7 @@ array([[ -4.05037121, -14.75623261],
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 To plot the resulting polygon, we have to pull out the x and y coordinates.
-
-
 
 ~~~
 pmra_poly, pmdec_poly = np.transpose(pm_vertices)
@@ -398,8 +323,6 @@ which are assigned to the two variables `pmra_poly` and `pmdec_poly`.
 
 The following figure shows proper motion in ICRS again, along with the
 convex hull we just computed.
-
-
 
 ~~~
 x = centerline_df['pmra']
@@ -424,13 +347,8 @@ plt.ylim([-20, 5]);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](04-select_files/04-select_29_0.png)
-    
-
 
 So `pm_vertices` represents the polygon we want to select.
 The next step is to use it as part of an ADQL query.
@@ -438,8 +356,6 @@ The next step is to use it as part of an ADQL query.
 ## Assembling the query
 
 In Lesson 2 we used the following query to select stars in a polygonal region.
-
-
 
 ~~~
 query5_base = """SELECT
@@ -462,8 +378,6 @@ the polygon we just computed, `pm_vertices`.
 
 Here are the coordinates of the larger rectangle in the GD-1 frame.
 
-
-
 ~~~
 import astropy.units as u
 
@@ -477,8 +391,6 @@ phi2_max = 5 * u.degree
 We selected these bounds by trial and error, defining the largest
 region we can process in a single query.
 
-
-
 ~~~
 phi1_rect, phi2_rect = make_rectangle(
     phi1_min, phi1_max, phi2_min, phi2_max)
@@ -486,8 +398,6 @@ phi1_rect, phi2_rect = make_rectangle(
 {: .language-python}
 
 Here's how we transform it to ICRS, as we saw in Lesson 2.
-
-
 
 ~~~
 from gala.coordinates import GD1Koposov10
@@ -506,8 +416,6 @@ To use `corners_icrs` as part of an ADQL query, we have to convert it
 to a string.
 Here's the function from Lesson 2 we used to do that.
 
-
-
 ~~~
 def skycoord_to_string(skycoord):
     """Convert SkyCoord to string."""
@@ -516,8 +424,6 @@ def skycoord_to_string(skycoord):
     return s.replace(' ', ', ')
 ~~~
 {: .language-python}
-
-
 
 ~~~
 point_list = skycoord_to_string(corners_icrs)
@@ -530,17 +436,7 @@ point_list
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Here are the columns we want to select.
-
-
 
 ~~~
 columns = 'source_id, ra, dec, pmra, pmdec'
@@ -548,9 +444,6 @@ columns = 'source_id, ra, dec, pmra, pmdec'
 {: .language-python}
 
 Now we have everything we need to assemble the query.
-
-
-
 
 ~~~
 query5 = query5_base.format(columns=columns, 
@@ -567,13 +460,8 @@ WHERE parallax < 1
   AND bp_rp BETWEEN -0.75 AND 2 
   AND 1 = CONTAINS(POINT(ra, dec), 
                    POLYGON(135.306, 8.39862, 126.51, 13.4449, 163.017, 54.2424, 172.933, 46.4726, 135.306, 8.39862))
-
-
 ~~~
 {: .output}
-
-
-    
 
 But don't try to run that query.
 Because it selects a larger region, there are too many stars to handle
@@ -589,8 +477,6 @@ To use `pm_vertices` as part of an ADQL query, we have to convert it
 to a string.
 Using `flatten` and `array2string`, we can almost get the format we need.
 
-
-
 ~~~
 s = np.array2string(pm_vertices.flatten(), 
                     max_line_width=1000,
@@ -604,17 +490,7 @@ s
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We just have to remove the brackets.
-
-
 
 ~~~
 pm_point_list = s.strip('[]')
@@ -627,14 +503,6 @@ pm_point_list
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 > ## Exercise
 > 
 > Define `query6_base`, starting with `query5_base` and adding a new
@@ -644,7 +512,6 @@ pm_point_list
 > > ## Solution
 > > 
 > > ~~~
-> > 
 > > query6_base = """SELECT 
 > > {columns}
 > > FROM gaiadr2.gaia_source
@@ -668,7 +535,6 @@ pm_point_list
 > > ## Solution
 > > 
 > > ~~~
-> > 
 > > query6 = query6_base.format(columns=columns, 
 > >                             point_list=point_list,
 > >                             pm_point_list=pm_point_list)
@@ -679,8 +545,6 @@ pm_point_list
 {: .challenge}
 
 Now we can run the query like this:
-
-
 
 ~~~
 from astroquery.gaia import Gaia
@@ -706,12 +570,7 @@ Phase: COMPLETED
 ~~~
 {: .output}
 
-
-    
-
 And get the results.
-
-
 
 ~~~
 candidate_table = job.get_results()
@@ -723,14 +582,6 @@ len(candidate_table)
 7345
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 We call the results `candidate_table` because it contains stars that
 are good candidates for GD-1.
@@ -744,8 +595,6 @@ We've seen how to save a `DataFrame` in an HDF file.
 We can do the same thing with a Pandas `Series`.
 To make one, we'll start with a dictionary:
 
-
-
 ~~~
 d = dict(point_list=point_list, pm_point_list=pm_point_list)
 d
@@ -758,17 +607,7 @@ d
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And use it to initialize a `Series.`
-
-
 
 ~~~
 point_series = pd.Series(d)
@@ -783,17 +622,7 @@ dtype: object
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can save it in the usual way.
-
-
 
 ~~~
 filename = 'gd1_data.hdf'
@@ -804,8 +633,6 @@ point_series.to_hdf(filename, 'point_series')
 ## Plotting one more time
 
 Let's see what the results look like.
-
-
 
 ~~~
 x = candidate_table['ra']
@@ -821,13 +648,8 @@ plt.ylabel('dec (degree ICRS)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](04-select_files/04-select_66_0.png)
-    
-
 
 Here we can see why it was useful to transform these coordinates.  In
 ICRS, it is more difficult to identity the stars near the centerline
@@ -836,8 +658,6 @@ of GD-1.
 So let's transform the results back to the GD-1 frame.
 Here's the code we used to transform the coordinates and make a Pandas
 `DataFrame`, wrapped in a function.
-
-
 
 ~~~
 from gala.coordinates import reflex_correct
@@ -872,16 +692,12 @@ def make_dataframe(table):
 
 Here's how we use it:
 
-
-
 ~~~
 candidate_df = make_dataframe(candidate_table)
 ~~~
 {: .language-python}
 
 And let's see the results.
-
-
 
 ~~~
 x = candidate_df['phi1']
@@ -897,13 +713,8 @@ plt.ylabel('phi2 (degree GD1)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+  
 ![png](04-select_files/04-select_72_0.png)
-    
-
 
 We're starting to see GD-1 more clearly.
 We can compare this figure with this panel from Figure 1 from the
@@ -942,17 +753,3 @@ we're able to either:
 
 In the next lesson, we'll learn about the database `JOIN` operation
 and use it to download photometry data from Pan-STARRS.
-
-## Best practices
-
-* When possible, "move the computation to the data"; that is, do as
-much of the work as possible on the database server before downloading
-the data.
-
-
-
-
-~~~
-
-~~~
-{: .language-python}

--- a/_episodes/05-join.md
+++ b/_episodes/05-join.md
@@ -3,19 +3,15 @@ title: "Join"
 teaching: 3000
 exercises: 0
 questions:
-
 - "How do we use `JOIN` to combine information from multiple tables?"
 
 objectives:
-
 - "Write ADQL queries involving `JOIN` operations."
 
 keypoints:
-
-- "Use `JOIN` operations to combine data from multiple tables in a database, using some kind of identifier to match up records from one table with records from another."
-
-- "This is another example of a practice we saw in the previous notebook, moving the computation to the data."
-
+- "Use `JOIN` operations to combine data from multiple tables in a database, using some kind of identifier to match up records from one table with records from another. This is another example of a practice we saw in the previous notebook, moving the computation to the data."
+- "For most applications, saving data in FITS or HDF5 is better than CSV.  FITS and HDF5 are binary formats, so the files are usually smaller, and they store metadata, so you don't lose anything when you read the file back."
+- "On the other hand, CSV is a "least common denominator" format; that is, it can be read by practically any application that works with data."
 ---
 
 {% include links.md %}
@@ -132,8 +128,6 @@ photometry data we want.
 Before we get to the `JOIN` operation, let's explore these tables.
 Here's the metadata for `panstarrs1_best_neighbour`.
 
-
-
 ~~~
 from astroquery.gaia import Gaia
 
@@ -145,14 +139,8 @@ meta = Gaia.load_table('gaiadr2.panstarrs1_best_neighbour')
 Retrieving table 'gaiadr2.panstarrs1_best_neighbour'
 Parsing table 'gaiadr2.panstarrs1_best_neighbour'...
 Done.
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 print(meta)
@@ -166,16 +154,10 @@ best neighbour in the external catalogue.
 There are 1 327 157 objects in the filtered version of Pan-STARRS1 used
 to compute this cross-match that have too early epochMean.
 Num. columns: 7
-
 ~~~
 {: .output}
 
-
-    
-
 And here are the columns.
-
-
 
 ~~~
 for column in meta.columns:
@@ -193,14 +175,10 @@ best_neighbour_multiplicity
 gaia_astrometric_params
 
 ~~~
-{: .output}
-
-
-    
+{: .output}  
 
 Here's the [documentation for these
-variables](https://gea.esac.esa.int/archive/documentation/GDR2/Gaia_archive/chap_datamodel/sec_dm_crossmatches/ssec_dm_panstarrs1_best_neighbour.html)
-.
+variables](https://gea.esac.esa.int/archive/documentation/GDR2/Gaia_archive/chap_datamodel/sec_dm_crossmatches/ssec_dm_panstarrs1_best_neighbour.html). 
 
 The ones we'll use are:
 
@@ -221,8 +199,6 @@ source in Gaia and the corresponding source in Pan-STARRS.
 
 Here's a query that selects these columns and returns the first 5 rows.
 
-
-
 ~~~
 query = """SELECT 
 TOP 5
@@ -232,8 +208,6 @@ FROM gaiadr2.panstarrs1_best_neighbour
 ~~~
 {: .language-python}
 
-
-
 ~~~
 job = Gaia.launch_job_async(query=query)
 ~~~
@@ -241,14 +215,8 @@ job = Gaia.launch_job_async(query=query)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -269,28 +237,9 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=5</i>
-<table id="table140523981953776" class="table-striped table-bordered table-condensed">
-<thead><tr><th>source_id</th><th>number_of_neighbours</th><th>number_of_mates</th><th>original_ext_source_id</th></tr></thead>
-<thead><tr><th>int64</th><th>int32</th><th>int16</th><th>int64</th></tr></thead>
-<tr><td>6745938972433480704</td><td>1</td><td>0</td><td>69742925668851205</td></tr>
-<tr><td>6030466788955954048</td><td>1</td><td>0</td><td>69742509325691172</td></tr>
-<tr><td>6756488099308169600</td><td>1</td><td>0</td><td>69742879438541228</td></tr>
-<tr><td>6700154994715046016</td><td>1</td><td>0</td><td>69743055581721207</td></tr>
-<tr><td>6757061941303252736</td><td>1</td><td>0</td><td>69742856540241198</td></tr>
-</table>
-
-
-
 ## The Pan-STARRS table
 
 Here's the metadata for the table that contains the Pan-STARRS data.
-
-
 
 ~~~
 meta = Gaia.load_table('gaiadr2.panstarrs1_original_valid')
@@ -301,14 +250,8 @@ meta = Gaia.load_table('gaiadr2.panstarrs1_original_valid')
 Retrieving table 'gaiadr2.panstarrs1_original_valid'
 Parsing table 'gaiadr2.panstarrs1_original_valid'...
 Done.
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 print(meta)
@@ -329,14 +272,9 @@ The current table contains a filtered subsample of the 10 723 304 629
 entries listed in the original ObjectThin table.
 [Output truncated]
 ~~~
-{: .output}
-
-
-    
+{: .output}  
 
 And here are the columns.
-
-
 
 ~~~
 for column in meta.columns:
@@ -360,9 +298,6 @@ r_mean_psf_mag
 ~~~
 {: .output}
 
-
-    
-
 Here's the [documentation for these variables]() .
 
 The ones we'll use are:
@@ -376,8 +311,6 @@ the best neighbor table.
 
 Here's a query that selects these variables and returns the first 5 rows.
 
-
-
 ~~~
 query = """SELECT 
 TOP 5
@@ -387,8 +320,6 @@ FROM gaiadr2.panstarrs1_original_valid
 ~~~
 {: .language-python}
 
-
-
 ~~~
 job = Gaia.launch_job_async(query=query)
 ~~~
@@ -396,14 +327,8 @@ job = Gaia.launch_job_async(query=query)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -425,24 +350,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=5</i>
-<table id="table140523984535712" class="table-striped table-bordered table-condensed">
-<thead><tr><th>obj_id</th><th>g_mean_psf_mag</th><th>i_mean_psf_mag</th></tr></thead>
-<thead><tr><th></th><th></th><th>mag</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th></tr></thead>
-<tr><td>67130655389101425</td><td>--</td><td>20.3516006469727</td></tr>
-<tr><td>67553305590067819</td><td>--</td><td>19.779899597168</td></tr>
-<tr><td>67551423248967849</td><td>--</td><td>19.8889007568359</td></tr>
-<tr><td>67132026238911331</td><td>--</td><td>20.9062995910645</td></tr>
-<tr><td>67553513677687787</td><td>--</td><td>21.2831001281738</td></tr>
-</table>
-
-
-
 The following figure shows how these tables are related.
 
 * The orange circles and arrows represent the first `JOIN` operation,
@@ -463,13 +370,10 @@ it](https://chartio.com/learn/databases/how-does-indexing-work/).
 <img
 src="https://github.com/datacarpentry/astronomy-python/raw/gh-pages/fig/join.png">
 
-
 ## Joining tables
 
 Now let's get to the details of performing a `JOIN` operation.
 As a starting place, let's go all the way back to the cone search from Lesson 2.
-
-
 
 ~~~
 query_cone = """SELECT 
@@ -485,8 +389,6 @@ WHERE 1=CONTAINS(
 
 And let's run it, to make sure we have a working query to build on.
 
-
-
 ~~~
 from astroquery.gaia import Gaia
 
@@ -496,14 +398,8 @@ job = Gaia.launch_job_async(query=query_cone)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -527,32 +423,8 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=10</i>
-<table id="table140523908331168" class="table-striped table-bordered table-condensed">
-<thead><tr><th>source_id</th></tr></thead>
-<thead><tr><th>int64</th></tr></thead>
-<tr><td>3322773965056065536</td></tr>
-<tr><td>3322773758899157120</td></tr>
-<tr><td>3322774068134271104</td></tr>
-<tr><td>3322773930696320512</td></tr>
-<tr><td>3322774377374425728</td></tr>
-<tr><td>3322773724537891456</td></tr>
-<tr><td>3322773724537891328</td></tr>
-<tr><td>3322773930696321792</td></tr>
-<tr><td>3322773724537890944</td></tr>
-<tr><td>3322773930696322176</td></tr>
-</table>
-
-
-
 Now we can start adding features.
 First, let's replace `source_id` with a format specifier, `columns`: 
-
-
 
 ~~~
 query_base = """SELECT 
@@ -566,8 +438,6 @@ WHERE 1=CONTAINS(
 {: .language-python}
 
 Here are the columns we want from the Gaia table, again. 
-
-
 
 ~~~
 columns = 'source_id, ra, dec, pmra, pmdec'
@@ -584,17 +454,10 @@ FROM gaiadr2.gaia_source
 WHERE 1=CONTAINS(
   POINT(ra, dec),
   CIRCLE(88.8, 7.4, 0.08333333))
-
-
 ~~~
 {: .output}
 
-
-    
-
 And let's run the query again.
-
-
 
 ~~~
 job = Gaia.launch_job_async(query=query)
@@ -603,14 +466,8 @@ job = Gaia.launch_job_async(query=query)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -634,39 +491,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=594</i>
-<table id="table140523908331456" class="table-striped table-bordered table-condensed">
-<thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th></tr></thead>
-<thead><tr><th></th><th>deg</th><th>deg</th><th>mas / yr</th><th>mas / yr</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>
-<tr><td>3322773965056065536</td><td>88.78178020183375</td><td>7.334936530583141</td><td>0.2980633722108194</td><td>-2.5057036964736907</td></tr>
-<tr><td>3322773758899157120</td><td>88.83227057144585</td><td>7.325577341429926</td><td>--</td><td>--</td></tr>
-<tr><td>3322774068134271104</td><td>88.8206092188033</td><td>7.353158142762173</td><td>-1.1065462654445488</td><td>-1.5260889445858044</td></tr>
-<tr><td>3322773930696320512</td><td>88.80843339290348</td><td>7.334853162299928</td><td>2.6074384482375215</td><td>-0.9292104395445717</td></tr>
-<tr><td>3322774377374425728</td><td>88.86806108182265</td><td>7.371287731275939</td><td>3.9555477866915383</td><td>-3.8676624830902435</td></tr>
-<tr><td>3322773724537891456</td><td>88.81308602813434</td><td>7.32488574492059</td><td>51.34995462741039</td><td>-33.078133430952086</td></tr>
-<tr><td>3322773724537891328</td><td>88.81570329208743</td><td>7.3223019772324855</td><td>1.9389988498951845</td><td>0.3110526931576576</td></tr>
-<tr><td>3322773930696321792</td><td>88.8050736770331</td><td>7.332371472206583</td><td>2.264014834476311</td><td>1.0772755505138008</td></tr>
-<tr><td>3322773724537890944</td><td>88.81241651540533</td><td>7.327864052479726</td><td>-0.36003627434304625</td><td>-6.393939291541333</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>3322962118983356032</td><td>88.76109637722949</td><td>7.380564308268047</td><td>--</td><td>--</td></tr>
-<tr><td>3322963527732585984</td><td>88.78813701704823</td><td>7.456696889759524</td><td>1.1363354614104264</td><td>-2.46251296961979</td></tr>
-<tr><td>3322961775385969024</td><td>88.79723215862369</td><td>7.359756552906535</td><td>2.121021366548921</td><td>-6.605711792572964</td></tr>
-<tr><td>3322962084625312512</td><td>88.78286756313868</td><td>7.384598632215225</td><td>-0.09350717810996487</td><td>1.3495903680571226</td></tr>
-<tr><td>3322962939322692608</td><td>88.73289357818679</td><td>7.407688975612043</td><td>-0.11002934783569704</td><td>1.002126813991455</td></tr>
-<tr><td>3322963768250760576</td><td>88.7592444035961</td><td>7.469624531882018</td><td>--</td><td>--</td></tr>
-<tr><td>3322963459013111808</td><td>88.80348931842845</td><td>7.438699901204871</td><td>0.800833828337078</td><td>-3.3780655466364626</td></tr>
-<tr><td>3322963355935626368</td><td>88.75528507586058</td><td>7.427795463027667</td><td>--</td><td>--</td></tr>
-<tr><td>3322963287216149888</td><td>88.7658164932195</td><td>7.415726370886557</td><td>2.3743092647634034</td><td>-0.5046963243400879</td></tr>
-<tr><td>3322962015904143872</td><td>88.74740822271643</td><td>7.387057037713974</td><td>-0.7201178533250112</td><td>0.5565841272341593</td></tr>
-</table>
-
-
-
 ## Adding the best neighbor table
 
 Now we're ready for the first join.
@@ -684,8 +508,6 @@ And the `ON` clause indicates that we'll match up the `source_id`
 column from the Gaia table with the `source_id` column from the best
 neighbor table.
 
-
-
 ~~~
 query_base = """SELECT 
 {columns}
@@ -699,22 +521,21 @@ WHERE 1=CONTAINS(
 ~~~
 {: .language-python}
 
-**SQL detail:** In this example, the `ON` column has the same name in
-both tables, so we could replace the `ON` clause with a simpler
-[`USING`
-clause](https://docs.oracle.com/javadb/10.8.3.0/ref/rrefsqljusing.html):
-
-```
-USING(source_id)
-```
+> ## SQL detail
+> In this example, the `ON` column has the same name in both tables, so we could replace the `ON` clause 
+> with a simpler [`USING`clause](https://docs.oracle.com/javadb/10.8.3.0/ref/rrefsqljusing.html):
+> 
+> ~~~
+> USING(source_id)
+> ~~~
+> {: .language-sql}
+{: .callout}
 
 Now that there's more than one table involved, we can't use simple
 column names any more; we have to use **qualified column names**.
 In other words, we have to specify which table each column is in.
 Here's the complete query, including the columns we want from the Gaia
 and best neighbor tables.
-
-
 
 ~~~
 column_list = ['gaia.source_id',
@@ -741,15 +562,8 @@ JOIN gaiadr2.panstarrs1_best_neighbour AS best
 WHERE 1=CONTAINS(
   POINT(gaia.ra, gaia.dec),
   CIRCLE(88.8, 7.4, 0.08333333))
-
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 job = Gaia.launch_job_async(query=query)
@@ -758,14 +572,8 @@ job = Gaia.launch_job_async(query=query)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -789,39 +597,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=490</i>
-<table id="table140524639163968" class="table-striped table-bordered table-condensed">
-<thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th><th>best_neighbour_multiplicity</th><th>number_of_mates</th></tr></thead>
-<thead><tr><th></th><th>deg</th><th>deg</th><th>mas / yr</th><th>mas / yr</th><th></th><th></th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>int16</th><th>int16</th></tr></thead>
-<tr><td>3322773965056065536</td><td>88.78178020183375</td><td>7.334936530583141</td><td>0.2980633722108194</td><td>-2.5057036964736907</td><td>1</td><td>0</td></tr>
-<tr><td>3322774068134271104</td><td>88.8206092188033</td><td>7.353158142762173</td><td>-1.1065462654445488</td><td>-1.5260889445858044</td><td>1</td><td>0</td></tr>
-<tr><td>3322773930696320512</td><td>88.80843339290348</td><td>7.334853162299928</td><td>2.6074384482375215</td><td>-0.9292104395445717</td><td>1</td><td>0</td></tr>
-<tr><td>3322774377374425728</td><td>88.86806108182265</td><td>7.371287731275939</td><td>3.9555477866915383</td><td>-3.8676624830902435</td><td>1</td><td>0</td></tr>
-<tr><td>3322773724537891456</td><td>88.81308602813434</td><td>7.32488574492059</td><td>51.34995462741039</td><td>-33.078133430952086</td><td>1</td><td>0</td></tr>
-<tr><td>3322773724537891328</td><td>88.81570329208743</td><td>7.3223019772324855</td><td>1.9389988498951845</td><td>0.3110526931576576</td><td>1</td><td>0</td></tr>
-<tr><td>3322773930696321792</td><td>88.8050736770331</td><td>7.332371472206583</td><td>2.264014834476311</td><td>1.0772755505138008</td><td>1</td><td>0</td></tr>
-<tr><td>3322773724537890944</td><td>88.81241651540533</td><td>7.327864052479726</td><td>-0.36003627434304625</td><td>-6.393939291541333</td><td>1</td><td>0</td></tr>
-<tr><td>3322773930696322176</td><td>88.80128682574824</td><td>7.334292036448643</td><td>--</td><td>--</td><td>1</td><td>0</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>3322962359501481088</td><td>88.85037722908271</td><td>7.402162717053584</td><td>2.058216493648542</td><td>-2.249255322558584</td><td>1</td><td>0</td></tr>
-<tr><td>3322962393861228544</td><td>88.82108234976155</td><td>7.4044425496203</td><td>-0.916760881643629</td><td>-1.1113319053861441</td><td>1</td><td>0</td></tr>
-<tr><td>3322955831151254912</td><td>88.74620347799508</td><td>7.342728619145855</td><td>0.1559833902071379</td><td>-1.750598455959734</td><td>1</td><td>0</td></tr>
-<tr><td>3322962118983356032</td><td>88.76109637722949</td><td>7.380564308268047</td><td>--</td><td>--</td><td>1</td><td>0</td></tr>
-<tr><td>3322963527732585984</td><td>88.78813701704823</td><td>7.456696889759524</td><td>1.1363354614104264</td><td>-2.46251296961979</td><td>1</td><td>0</td></tr>
-<tr><td>3322961775385969024</td><td>88.79723215862369</td><td>7.359756552906535</td><td>2.121021366548921</td><td>-6.605711792572964</td><td>1</td><td>0</td></tr>
-<tr><td>3322962084625312512</td><td>88.78286756313868</td><td>7.384598632215225</td><td>-0.09350717810996487</td><td>1.3495903680571226</td><td>1</td><td>0</td></tr>
-<tr><td>3322962939322692608</td><td>88.73289357818679</td><td>7.407688975612043</td><td>-0.11002934783569704</td><td>1.002126813991455</td><td>1</td><td>0</td></tr>
-<tr><td>3322963459013111808</td><td>88.80348931842845</td><td>7.438699901204871</td><td>0.800833828337078</td><td>-3.3780655466364626</td><td>1</td><td>0</td></tr>
-<tr><td>3322962015904143872</td><td>88.74740822271643</td><td>7.387057037713974</td><td>-0.7201178533250112</td><td>0.5565841272341593</td><td>1</td><td>0</td></tr>
-</table>
-
-
-
 Notice that this result has fewer rows than the previous result.
 That's because there are sources in the Gaia table with no
 corresponding source in the Pan-STARRS table.
@@ -835,23 +610,20 @@ here](https://www.geeksforgeeks.org/sql-join-set-1-inner-left-right-and-full-joi
 
 ## Adding the Pan-STARRS table
 
-### Exercise
-
-Now we're ready to bring in the Pan-STARRS table.  Starting with the
-previous query, add a second `JOIN` clause that joins with
-`gaiadr2.panstarrs1_original_valid`, gives it the abbreviated name
-`ps`, and matches `original_ext_source_id` from the best neighbor
-table with `obj_id` from the Pan-STARRS table.
-
-Add `g_mean_psf_mag` and `i_mean_psf_mag` to the column list, and run the query.
-The result should contain 490 rows and 9 columns.
-
-
+> ## Exercise
+> 
+> Now we're ready to bring in the Pan-STARRS table.  Starting with the
+> previous query, add a second `JOIN` clause that joins with
+> `gaiadr2.panstarrs1_original_valid`, gives it the abbreviated name
+> `ps`, and matches `original_ext_source_id` from the best neighbor
+> table with `obj_id` from the Pan-STARRS table.
+> 
+> Add `g_mean_psf_mag` and `i_mean_psf_mag` to the column list, and run the query.
+> The result should contain 490 rows and 9 columns.
 >
 > > ## Solution
 > > 
 > > ~~~
-> > 
 > > query_base = """SELECT 
 > > {columns}
 > > FROM gaiadr2.gaia_source as gaia
@@ -883,6 +655,7 @@ The result should contain 490 rows and 9 columns.
 > > results = job.get_results()
 > > results
 > > ~~~
+> > 
 > > {: .language-python}
 > {: .solution}
 {: .challenge}
@@ -894,8 +667,6 @@ selects sources based on parallax, BP-RP color, sky coordinates, and
 proper motion.
 
 Here's `query6_base` from the previous lesson.
-
-
 
 ~~~
 query6_base = """SELECT 
@@ -913,8 +684,6 @@ WHERE parallax < 1
 
 Let's reload the Pandas `Series` that contains `point_list` and `pm_point_list`.
 
-
-
 ~~~
 import pandas as pd
 
@@ -931,17 +700,7 @@ dtype: object
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can assemble the query.
-
-
 
 ~~~
 columns = 'source_id, ra, dec, pmra, pmdec'
@@ -964,17 +723,10 @@ WHERE parallax < 1
                    POLYGON(135.306, 8.39862, 126.51, 13.4449, 163.017, 54.2424, 172.933, 46.4726, 135.306, 8.39862))
   AND 1 = CONTAINS(POINT(pmra, pmdec),
                    POLYGON( -4.05037121,-14.75623261, -3.41981085,-14.72365546, -3.03521988,-14.44357135, -2.26847919,-13.7140236 , -2.61172203,-13.24797471, -2.73471401,-13.09054471, -3.19923146,-12.5942653 , -3.34082546,-12.47611926, -5.67489413,-11.16083338, -5.95159272,-11.10547884, -6.42394023,-11.05981295, -7.09631023,-11.95187806, -7.30641519,-12.24559977, -7.04016696,-12.88580702, -6.00347705,-13.75912098, -4.42442296,-14.74641176))
-
-
 ~~~
 {: .output}
 
-
-    
-
 Again, let's run it to make sure we are starting with a working query.
-
-
 
 ~~~
 job = Gaia.launch_job_async(query=query6)
@@ -983,14 +735,8 @@ job = Gaia.launch_job_async(query=query6)
 
 ~~~
 INFO: Query finished. [astroquery.utils.tap.core]
-
 ~~~
 {: .output}
-
-
-    
-
-
 
 ~~~
 results = job.get_results()
@@ -1014,39 +760,6 @@ results
 ~~~
 {: .output}
 
-
-
-
-
-<i>Table length=7345</i>
-<table id="table140523982340048" class="table-striped table-bordered table-condensed">
-<thead><tr><th>source_id</th><th>ra</th><th>dec</th><th>pmra</th><th>pmdec</th></tr></thead>
-<thead><tr><th></th><th>deg</th><th>deg</th><th>mas / yr</th><th>mas / yr</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>
-<tr><td>635559124339440000</td><td>137.58671691646745</td><td>19.1965441084838</td><td>-3.770521900009566</td><td>-12.490481778113859</td></tr>
-<tr><td>635860218726658176</td><td>138.5187065217173</td><td>19.09233926905897</td><td>-5.941679495793577</td><td>-11.346409129876392</td></tr>
-<tr><td>635674126383965568</td><td>138.8428741026386</td><td>19.031798198627634</td><td>-3.8970011609340207</td><td>-12.702779525389634</td></tr>
-<tr><td>635535454774983040</td><td>137.8377518255436</td><td>18.864006786112604</td><td>-4.335040664412791</td><td>-14.492308604905652</td></tr>
-<tr><td>635497276810313600</td><td>138.0445160213759</td><td>19.00947118796605</td><td>-7.1729306406216615</td><td>-12.291499169815987</td></tr>
-<tr><td>635614168640132864</td><td>139.59219748145836</td><td>18.807955539071433</td><td>-3.309602916796381</td><td>-13.708904908478631</td></tr>
-<tr><td>635821843194387840</td><td>139.88094034815086</td><td>19.62185456718988</td><td>-6.544201177153814</td><td>-12.55978220563274</td></tr>
-<tr><td>635551706931167104</td><td>138.04665586038192</td><td>19.248909662830798</td><td>-6.224595114220405</td><td>-12.224246333795001</td></tr>
-<tr><td>635518889086133376</td><td>137.2374229207837</td><td>18.7428630711791</td><td>-3.3186800714801046</td><td>-12.710314902969365</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>612282738058264960</td><td>134.0445768189235</td><td>18.11915820167003</td><td>-2.5972485319419127</td><td>-13.651740929272187</td></tr>
-<tr><td>612485911486166656</td><td>134.96582769047063</td><td>19.309965857307247</td><td>-4.519325315774155</td><td>-11.998725329569156</td></tr>
-<tr><td>612386332668697600</td><td>135.45701048323093</td><td>18.63266345155342</td><td>-5.07684899854408</td><td>-12.436641304786672</td></tr>
-<tr><td>612296172717818624</td><td>133.80060286960668</td><td>18.08186533343457</td><td>-6.112792578821885</td><td>-12.50750861370402</td></tr>
-<tr><td>612250375480101760</td><td>134.64754712466774</td><td>18.122419425065015</td><td>-2.8969262278467127</td><td>-14.061676353845487</td></tr>
-<tr><td>612394926899159168</td><td>135.51997060013844</td><td>18.817675531233004</td><td>-3.9968965218753763</td><td>-13.526821099431533</td></tr>
-<tr><td>612288854091187712</td><td>134.07970733489358</td><td>18.15424015818678</td><td>-5.96977151283562</td><td>-11.162471664228455</td></tr>
-<tr><td>612428870024913152</td><td>134.8384242853297</td><td>18.758253070693225</td><td>-4.0022333299353825</td><td>-14.247379430659198</td></tr>
-<tr><td>612256418500423168</td><td>134.90752972739924</td><td>18.280596648172743</td><td>-6.109836304219565</td><td>-12.145212331165776</td></tr>
-<tr><td>612429144902815104</td><td>134.77293979509543</td><td>18.73628415871413</td><td>-5.257085979310591</td><td>-13.962312685889454</td></tr>
-</table>
-
-
-
 > ## Exercise
 > 
 > Create a new query base called `query7_base` that combines the `WHERE`
@@ -1063,7 +776,6 @@ results
 > > ## Solution
 > > 
 > > ~~~
-> > 
 > > query7_base = """
 > > SELECT 
 > > {columns}
@@ -1102,8 +814,6 @@ To get more information about the matching process, we can inspect
 `best_neighbour_multiplicity`, which indicates for each star in Gaia
 how many stars in Pan-STARRS are equally likely matches.
 
-
-
 ~~~
 results['best_neighbour_multiplicity']
 ~~~
@@ -1125,41 +835,6 @@ results['best_neighbour_multiplicity']
 ~~~
 {: .output}
 
-
-
-
-
-&lt;MaskedColumn name=&apos;best_neighbour_multiplicity&apos; dtype=&apos;int16&apos; description=&apos;Number of neighbours with same probability as best neighbour&apos; length=3725&gt;
-<table>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>...</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-<tr><td>1</td></tr>
-</table>
-
-
-
 It looks like most of the values are `1`, which is good; that means
 that for each candidate star we have identified exactly one source in
 Pan-STARRS that is likely to be the same star.
@@ -1167,8 +842,6 @@ Pan-STARRS that is likely to be the same star.
 To check whether there are any values other than `1`, we can convert
 this column to a Pandas `Series` and use `describe`, which we saw in
 in Lesson 3.
-
-
 
 ~~~
 import pandas as pd
@@ -1191,21 +864,11 @@ dtype: float64
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 In fact, `1` is the only value in the `Series`, so every candidate
 star has a single best match.
 
 Similarly, `number_of_mates` indicates the number of *other* stars in
 Gaia that match with the same star in Pan-STARRS.
-
-
 
 ~~~
 mates = pd.Series(results['number_of_mates'])
@@ -1226,14 +889,6 @@ dtype: float64
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 All values in this column are `0`, which means that for each match we
 found in Pan-STARRS, there are no other stars in Gaia that also match.
 
@@ -1246,8 +901,6 @@ interested in the final match, using both criteria.
 
 Here's the function we've used to transform the results from ICRS to
 GD-1 coordinates.
-
-
 
 ~~~
 import astropy.units as u
@@ -1285,16 +938,12 @@ def make_dataframe(table):
 
 Now can transform the result from the last query.
 
-
-
 ~~~
 candidate_df = make_dataframe(results)
 ~~~
 {: .language-python}
 
 And see how it looks.
-
-
 
 ~~~
 import matplotlib.pyplot as plt
@@ -1312,13 +961,8 @@ plt.ylabel('phi2 (degree GD1)');
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+  
 ![png](05-join_files/05-join_70_0.png)
-    
-
 
 The result is similar to what we saw in the previous lesson, except
 that have fewer stars now, because we did not find photometry data for
@@ -1330,8 +974,6 @@ Let's save this `DataFrame` so we can pick up where we left off
 without running this query again.
 The HDF file should already exist, so we'll add `candidate_df` to it.
 
-
-
 ~~~
 filename = 'gd1_data.hdf'
 
@@ -1340,8 +982,6 @@ candidate_df.to_hdf(filename, 'candidate_df')
 {: .language-python}
 
 We can use `getsize` to confirm that the file exists and check the size:
-
-
 
 ~~~
 from os.path import getsize
@@ -1355,14 +995,6 @@ getsize(filename) / MB
 3.5835609436035156
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 ## Summary
 
@@ -1397,16 +1029,12 @@ Also, CSV files tend to be big, and slow to read and write.
 
 With those caveats, here's how to write one:
 
-
-
 ~~~
 candidate_df.to_csv('gd1_data.csv')
 ~~~
 {: .language-python}
 
 We can check the file size like this:
-
-
 
 ~~~
 getsize('gd1_data.csv') / MB
@@ -1418,17 +1046,7 @@ getsize('gd1_data.csv') / MB
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can see the first few lines like this:
-
-
 
 ~~~
 def head(filename, n=3):
@@ -1438,8 +1056,6 @@ def head(filename, n=3):
             print(next(fp))
 ~~~
 {: .language-python}
-
-
 
 ~~~
 head('gd1_data.csv')
@@ -1452,19 +1068,12 @@ head('gd1_data.csv')
 0,635860218726658176,138.5187065217173,19.09233926905897,-5.941679495793577,-11.346409129876392,1,0,17.8978004455566,17.5174007415771,-59.247329893833296,-2.016078400820631,-7.527126084640531,1.7487794924176672
 
 1,635674126383965568,138.8428741026386,19.031798198627634,-3.8970011609340207,-12.702779525389634,1,0,19.2873001098633,17.6781005859375,-59.13339098769217,-2.306900745179831,-7.560607655557415,-0.7417999555980248
-
-
 ~~~
-{: .output}
-
-
-    
+{: .output}  
 
 The CSV file contains the names of the columns, but not the data types.
 
 We can read the CSV file back like this:
-
-
 
 ~~~
 read_back_csv = pd.read_csv('gd1_data.csv')
@@ -1472,8 +1081,6 @@ read_back_csv = pd.read_csv('gd1_data.csv')
 {: .language-python}
 
 Let's compare the first few rows of `candidate_df` and `read_back_csv`
-
-
 
 ~~~
 candidate_df.head(3)
@@ -1496,100 +1103,6 @@ candidate_df.head(3)
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>source_id</th>
-      <th>ra</th>
-      <th>dec</th>
-      <th>pmra</th>
-      <th>pmdec</th>
-      <th>best_neighbour_multiplicity</th>
-      <th>number_of_mates</th>
-      <th>g_mean_psf_mag</th>
-      <th>i_mean_psf_mag</th>
-      <th>phi1</th>
-      <th>phi2</th>
-      <th>pm_phi1</th>
-      <th>pm_phi2</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>635860218726658176</td>
-      <td>138.518707</td>
-      <td>19.092339</td>
-      <td>-5.941679</td>
-      <td>-11.346409</td>
-      <td>1</td>
-      <td>0</td>
-      <td>17.8978</td>
-      <td>17.517401</td>
-      <td>-59.247330</td>
-      <td>-2.016078</td>
-      <td>-7.527126</td>
-      <td>1.748779</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>635674126383965568</td>
-      <td>138.842874</td>
-      <td>19.031798</td>
-      <td>-3.897001</td>
-      <td>-12.702780</td>
-      <td>1</td>
-      <td>0</td>
-      <td>19.2873</td>
-      <td>17.678101</td>
-      <td>-59.133391</td>
-      <td>-2.306901</td>
-      <td>-7.560608</td>
-      <td>-0.741800</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>635535454774983040</td>
-      <td>137.837752</td>
-      <td>18.864007</td>
-      <td>-4.335041</td>
-      <td>-14.492309</td>
-      <td>1</td>
-      <td>0</td>
-      <td>16.9238</td>
-      <td>16.478100</td>
-      <td>-59.785300</td>
-      <td>-1.594569</td>
-      <td>-9.357536</td>
-      <td>-1.218492</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
-
-
 ~~~
 read_back_csv.head(3)
 ~~~
@@ -1611,128 +1124,7 @@ read_back_csv.head(3)
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>Unnamed: 0</th>
-      <th>source_id</th>
-      <th>ra</th>
-      <th>dec</th>
-      <th>pmra</th>
-      <th>pmdec</th>
-      <th>best_neighbour_multiplicity</th>
-      <th>number_of_mates</th>
-      <th>g_mean_psf_mag</th>
-      <th>i_mean_psf_mag</th>
-      <th>phi1</th>
-      <th>phi2</th>
-      <th>pm_phi1</th>
-      <th>pm_phi2</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>0</td>
-      <td>635860218726658176</td>
-      <td>138.518707</td>
-      <td>19.092339</td>
-      <td>-5.941679</td>
-      <td>-11.346409</td>
-      <td>1</td>
-      <td>0</td>
-      <td>17.8978</td>
-      <td>17.517401</td>
-      <td>-59.247330</td>
-      <td>-2.016078</td>
-      <td>-7.527126</td>
-      <td>1.748779</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>1</td>
-      <td>635674126383965568</td>
-      <td>138.842874</td>
-      <td>19.031798</td>
-      <td>-3.897001</td>
-      <td>-12.702780</td>
-      <td>1</td>
-      <td>0</td>
-      <td>19.2873</td>
-      <td>17.678101</td>
-      <td>-59.133391</td>
-      <td>-2.306901</td>
-      <td>-7.560608</td>
-      <td>-0.741800</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>2</td>
-      <td>635535454774983040</td>
-      <td>137.837752</td>
-      <td>18.864007</td>
-      <td>-4.335041</td>
-      <td>-14.492309</td>
-      <td>1</td>
-      <td>0</td>
-      <td>16.9238</td>
-      <td>16.478100</td>
-      <td>-59.785300</td>
-      <td>-1.594569</td>
-      <td>-9.357536</td>
-      <td>-1.218492</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 Notice that the index in `candidate_df` has become an unnamed column
 in `read_back_csv`.  The Pandas functions for writing and reading CSV
 files provide options to avoid that problem, but this is an example of
 the kind of thing that can go wrong with CSV files.
-
-## Best practices
-
-* Use `JOIN` operations to combine data from multiple tables in a
-databased, using some kind of identifier to match up records from one
-table with records from another.
-
-* This is another example of a practice we saw in the previous
-notebook, moving the computation to the data.
-
-* For most applications, saving data in FITS or HDF5 is better than
-CSV.  FITS and HDF5 are binary formats, so the files are usually
-smaller, and they store metadata, so you don't lose anything when you
-read the file back.
-
-* On the other hand, CSV is a "least common denominator" format; that
-is, it can be read by practically any application that works with
-data.
-
-
-
-~~~
-
-~~~
-{: .language-python}

--- a/_episodes/06-photo.md
+++ b/_episodes/06-photo.md
@@ -3,23 +3,16 @@ title: "Photometry"
 teaching: 3000
 exercises: 0
 questions:
-
 - "How do we use Matplotlib to define a polygon and select points that fall inside it?"
 
 objectives:
-
 - "Use isochrone data to specify a polygon and determine which points fall inside it."
-
 - "Use Matplotlib features to customize the appearance of figures."
 
 keypoints:
-
 - "Matplotlib provides operations for working with points, polygons, and other geometric entities, so it's not just for making figures."
-
 - "Use Matplotlib options to control the size and aspect ratio of figures to make them easier to interpret."
-
 - "Record every element of the data analysis pipeline that would be needed to replicate the results."
-
 ---
 
 {% include links.md %}
@@ -76,8 +69,6 @@ You can [download the data from the previous
 lesson](https://github.com/AllenDowney/AstronomicalData/raw/main/data/gd1_data.hdf)
 or run the following cell, which downloads it if necessary.
 
-
-
 ~~~
 from os.path import basename, exists
 
@@ -94,8 +85,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 {: .language-python}
 
 Now we can reload `candidate_df`.
-
-
 
 ~~~
 import pandas as pd
@@ -137,10 +126,6 @@ draws a color-magnitude diagram.
 The input can be an Astropy `Table` or Pandas `DataFrame`, as long as
 it has columns named `g_mean_psf_mag` and `i_mean_psf_mag`.
 
-
-
-
-
 ~~~
 import matplotlib.pyplot as plt
 
@@ -167,30 +152,31 @@ def plot_cmd(table):
 axis, which is conventional when plotting magnitudes, since lower
 magnitude indicates higher brightness.
 
-`invert_yaxis` is a little different from the other functions we've
-used.  You can't call it like this:
-
-```
-plt.invert_yaxis()          # doesn't work
-```
-
-You have to call it like this:
-
-```
-plt.gca().invert_yaxis()          # works
-```
+~~~
+plt.gca().invert_yaxis()
+~~~
+{: .language-python}
 
 `gca` stands for "get current axis".  It returns an object that
 represents the axes of the current figure, and that object provides
 `invert_yaxis`.
 
-**In case anyone asks:** The most likely reason for this inconsistency
-in the interface is that `invert_yaxis` is a lesser-used function, so
-it's not made available at the top level of the interface.
+> ## Warning 
+> 
+> `invert_yaxis` is a little different from the other functions we've
+> used.  You can't call it like this:
+> 
+> ~~~
+> plt.invert_yaxis()
+> ~~~
+> {: .language-python}
+> 
+> The most likely reason for this inconsistency
+> in the interface is that `invert_yaxis` is a lesser-used function, so
+> it's not made available at the top level of the interface.
+{: .error}
 
 Here's what the results look like.
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -201,14 +187,9 @@ plot_cmd(candidate_df)
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](06-photo_files/06-photo_12_0.png)
-    
-
-
+ 
 Our figure does not look exactly like the one in the paper because we
 are working with a smaller region of the sky, so we don't have as many
 stars.  But we can see an overdense region in the lower left that
@@ -244,8 +225,6 @@ computed an isochrone with the following parameters:
 
 The following cell downloads the results:
 
-
-
 ~~~
 download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
          'data/MIST_iso_5fd2532653c27.iso.cmd')
@@ -255,8 +234,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 To read this file we'll download a Python module [from this
 repository](https://github.com/jieunchoi/MIST_codes).
 
-
-
 ~~~
 download('https://github.com/jieunchoi/MIST_codes/raw/master/scripts/' +
          'read_mist_models.py')
@@ -264,8 +241,6 @@ download('https://github.com/jieunchoi/MIST_codes/raw/master/scripts/' +
 {: .language-python}
 
 Now we can read the file:
-
-
 
 ~~~
 import read_mist_models
@@ -277,16 +252,10 @@ iso = read_mist_models.ISOCMD(filename)
 
 ~~~
 Reading in: MIST_iso_5fd2532653c27.iso.cmd
-
 ~~~
 {: .output}
 
-
-    
-
 The result is an `ISOCMD` object.
-
-
 
 ~~~
 type(iso)
@@ -298,17 +267,7 @@ read_mist_models.ISOCMD
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 It contains a list of arrays, one for each isochrone.
-
-
 
 ~~~
 type(iso.isocmds)
@@ -320,17 +279,7 @@ list
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We only got one isochrone.
-
-
 
 ~~~
 len(iso.isocmds)
@@ -342,17 +291,7 @@ len(iso.isocmds)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 So we can select it like this:
-
-
 
 ~~~
 iso_array = iso.isocmds[0]
@@ -360,8 +299,6 @@ iso_array = iso.isocmds[0]
 {: .language-python}
 
 It's a NumPy array:
-
-
 
 ~~~
 type(iso_array)
@@ -373,17 +310,7 @@ numpy.ndarray
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 But it's an unusual NumPy array, because it contains names for the columns.
-
-
 
 ~~~
 iso_array.dtype
@@ -395,17 +322,7 @@ dtype([('EEP', '<i4'), ('isochrone_age_yr', '<f8'), ('initial_mass', '<f8'), ('s
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Which means we can select columns using the bracket operator:
-
-
 
 ~~~
 iso_array['phase']
@@ -417,18 +334,8 @@ array([0., 0., 0., ..., 6., 6., 6.])
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can use `phase` to select the part of the isochrone for stars in
 the main sequence and red giant phases.
-
-
 
 ~~~
 phase_mask = (iso_array['phase'] >= 0) & (iso_array['phase'] < 3)
@@ -441,16 +348,6 @@ phase_mask.sum()
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
-
-
 ~~~
 main_sequence = iso_array[phase_mask]
 len(main_sequence)
@@ -462,14 +359,6 @@ len(main_sequence)
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The other two columns we'll use are `PS_g` and `PS_i`, which contain
 simulated photometry data for stars with the given age and
 metallicity, based on a model of the Pan-STARRS sensors.
@@ -480,8 +369,6 @@ modulus](https://en.wikipedia.org/wiki/Distance_modulus) to scale the
 isochrone based on the estimated distance of GD-1.
 
 We can use the `Distance` object from Astropy to compute the distance modulus.
-
-
 
 ~~~
 import astropy.coordinates as coord
@@ -498,17 +385,7 @@ distmod
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can compute the scaled magnitude and color of the isochrone.
-
-
 
 ~~~
 mag_g = main_sequence['PS_g'] + distmod
@@ -517,8 +394,6 @@ color_g_i = main_sequence['PS_g'] - main_sequence['PS_i']
 {: .language-python}
 
 Now we can plot it on the color-magnitude diagram like this.
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -530,13 +405,8 @@ plt.plot(color_g_i, mag_g);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+  
 ![png](06-photo_files/06-photo_42_0.png)
-    
-
 
 The theoretical isochrone passes through the overdense region where we
 expect to find stars in GD-1.
@@ -546,8 +416,6 @@ steps in this section.
 
 So we can save the data in an HDF5 file, we'll put it in a Pandas
 `DataFrame` first:
-
-
 
 ~~~
 import pandas as pd
@@ -570,67 +438,7 @@ iso_df.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>mag_g</th>
-      <th>color_g_i</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>28.294743</td>
-      <td>2.195021</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>28.189718</td>
-      <td>2.166076</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>28.051761</td>
-      <td>2.129312</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>27.916194</td>
-      <td>2.093721</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>27.780024</td>
-      <td>2.058585</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 And then save it.
-
-
 
 ~~~
 filename = 'gd1_isochrone.hdf5'
@@ -643,8 +451,6 @@ iso_df.to_hdf(filename, 'iso_df')
 The following cell downloads the isochrone we made in the previous
 section, if necessary.
 
-
-
 ~~~
 download('https://github.com/AllenDowney/AstronomicalData/raw/main/data/' +
          'gd1_isochrone.hdf5')
@@ -652,8 +458,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/data/' +
 {: .language-python}
 
 Now we can read it back in.
-
-
 
 ~~~
 filename = 'gd1_isochrone.hdf5'
@@ -672,67 +476,7 @@ iso_df.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>mag_g</th>
-      <th>color_g_i</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>28.294743</td>
-      <td>2.195021</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>28.189718</td>
-      <td>2.166076</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>28.051761</td>
-      <td>2.129312</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>27.916194</td>
-      <td>2.093721</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>27.780024</td>
-      <td>2.058585</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 Here's what the isochrone looks like on the color-magnitude diagram.
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -745,12 +489,7 @@ plt.plot(iso_df['color_g_i'], iso_df['mag_g']);
 ~~~
 {: .output}
 
-
-
-    
 ![png](06-photo_files/06-photo_52_0.png)
-    
-
 
 In the bottom half of the figure, the isochrone passes through the
 overdense region where the stars are likely to belong to GD-1.
@@ -762,8 +501,6 @@ in GD-1.
 So we'll select the part of the isochrone that lies in the overdense region.
 
 `g_mask` is a Boolean Series that is `True` where `g` is between 18.0 and 21.5.
-
-
 
 ~~~
 g = iso_df['mag_g']
@@ -778,17 +515,7 @@ g_mask.sum()
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 We can use it to select the corresponding rows in `iso_df`:
-
-
 
 ~~~
 iso_masked = iso_df[g_mask]
@@ -806,71 +533,11 @@ iso_masked.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>mag_g</th>
-      <th>color_g_i</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>94</th>
-      <td>21.411746</td>
-      <td>0.692171</td>
-    </tr>
-    <tr>
-      <th>95</th>
-      <td>21.322466</td>
-      <td>0.670238</td>
-    </tr>
-    <tr>
-      <th>96</th>
-      <td>21.233380</td>
-      <td>0.648449</td>
-    </tr>
-    <tr>
-      <th>97</th>
-      <td>21.144427</td>
-      <td>0.626924</td>
-    </tr>
-    <tr>
-      <th>98</th>
-      <td>21.054549</td>
-      <td>0.605461</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 Now, to select the stars in the overdense region, we have to define a
 polygon that includes stars near the isochrone.
 
 The original paper uses the following formulas to define the left and
 right boundaries.
-
-
 
 ~~~
 g = iso_masked['mag_g']
@@ -884,8 +551,6 @@ to reflect increasing uncertainty.
 
 But we can do about as well with a simpler formula:
 
-
-
 ~~~
 g = iso_masked['mag_g']
 left_color = iso_masked['color_g_i'] - 0.06
@@ -894,8 +559,6 @@ right_color = iso_masked['color_g_i'] + 0.12
 {: .language-python}
 
 Here's what these boundaries look like:
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -911,13 +574,8 @@ plt.legend();
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](06-photo_files/06-photo_62_0.png)
-    
-
 
 ## Which points are in the polygon?
 
@@ -930,8 +588,6 @@ to the points of `right_color` in reverse order.
 
 We'll use the following function, which takes two arrays and joins
 them front-to-back:
-
-
 
 ~~~
 import numpy as np
@@ -962,8 +618,6 @@ And `step` is `-1`, which means the elements are in reverse order.
 We can use `front_to_back` to make a loop that includes the elements
 of `left_color` and `right_color`:
 
-
-
 ~~~
 color_loop = front_to_back(left_color, right_color)
 color_loop.shape
@@ -975,17 +629,7 @@ color_loop.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And a corresponding loop with the elements of `g` in forward and reverse order.
-
-
 
 ~~~
 mag_loop = front_to_back(g, g)
@@ -998,17 +642,7 @@ mag_loop.shape
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Here's what the loop looks like.
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -1020,18 +654,11 @@ plt.plot(color_loop, mag_loop);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](06-photo_files/06-photo_70_0.png)
-    
-
 
 To make a `Polygon`, it will be convenient to put `color_loop` and
 `mag_loop` into a `DataFrame`:
-
-
 
 ~~~
 loop_df = pd.DataFrame()
@@ -1051,67 +678,7 @@ loop_df.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>color_loop</th>
-      <th>mag_loop</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>0.632171</td>
-      <td>21.411746</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>0.610238</td>
-      <td>21.322466</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>0.588449</td>
-      <td>21.233380</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>0.566924</td>
-      <td>21.144427</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>0.545461</td>
-      <td>21.054549</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 Now we can pass `loop_df` to `Polygon`:
-
-
 
 ~~~
 from matplotlib.patches import Polygon
@@ -1126,21 +693,11 @@ polygon
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is a `Polygon` object , which provides `contains_points`,
 which figures out which points are inside the polygon.
 
 To test it, we'll create a list with two points, one inside the
 polygon and one outside.
-
-
 
 ~~~
 points = [(0.4, 20), 
@@ -1149,8 +706,6 @@ points = [(0.4, 20),
 {: .language-python}
 
 Now we can make sure `contains_points` does what we expect.
-
-
 
 ~~~
 inside = polygon.contains_points(points)
@@ -1162,14 +717,6 @@ inside
 array([ True, False])
 ~~~
 {: .output}
-
-
-
-
-
-    
-
-
 
 The result is an array of Boolean values.
 
@@ -1195,8 +742,6 @@ So it is important to record the polygon as part of the data analysis pipeline.
 
 Here's how we can save it in an HDF file.
 
-
-
 ~~~
 filename = 'gd1_data.hdf'
 loop_df.to_hdf(filename, 'loop_df')
@@ -1207,8 +752,6 @@ loop_df.to_hdf(filename, 'loop_df')
 
 Now let's see how many of the candidate stars are inside the polygon we chose.
 We'll put color and magnitude data from `candidate_df` into a new `DataFrame`:
-
-
 
 ~~~
 points = pd.DataFrame()
@@ -1230,67 +773,7 @@ points.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>color</th>
-      <th>mag</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>0.3804</td>
-      <td>17.8978</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>1.6092</td>
-      <td>19.2873</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>0.4457</td>
-      <td>16.9238</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>1.5902</td>
-      <td>19.9242</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>1.4853</td>
-      <td>16.1516</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 Which we can pass to `contains_points`:
-
-
 
 ~~~
 inside = polygon.contains_points(points)
@@ -1303,18 +786,8 @@ array([False, False, False, ..., False, False, False])
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The result is a Boolean array.  We can use `sum` to see how many stars
 fall in the polygon.
-
-
 
 ~~~
 inside.sum()
@@ -1326,17 +799,7 @@ inside.sum()
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Now we can use `inside` as a mask to select stars that fall inside the polygon.
-
-
 
 ~~~
 winner_df = candidate_df[inside]
@@ -1345,8 +808,6 @@ winner_df = candidate_df[inside]
 
 Let's make a color-magnitude plot one more time, highlighting the
 selected stars with green markers.
-
-
 
 ~~~
 plot_cmd(candidate_df)
@@ -1363,20 +824,13 @@ plt.plot(x, y, 'go', markersize=0.5, alpha=0.5);
 <Figure size 432x288 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](06-photo_files/06-photo_91_0.png)
-    
-
 
 It looks like the selected stars are, in fact, inside the polygon,
 which means they have photometry data consistent with GD-1.
 
 Finally, we can plot the coordinates of the selected stars:
-
-
 
 ~~~
 plt.figure(figsize=(10,2.5))
@@ -1396,13 +850,8 @@ plt.axis('equal');
 <Figure size 720x180 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+  
 ![png](06-photo_files/06-photo_93_0.png)
-    
-
 
 This example includes two new Matplotlib commands:
 
@@ -1422,15 +871,11 @@ represented accurately.
 
 Finally, let's write the selected stars to a file.
 
-
-
 ~~~
 filename = 'gd1_data.hdf'
 winner_df.to_hdf(filename, 'winner_df')
 ~~~
 {: .language-python}
-
-
 
 ~~~
 from os.path import getsize
@@ -1445,14 +890,6 @@ getsize(filename) / MB
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 ## Summary
 
 In this lesson, we used photometry data from Pan-STARRS to draw a
@@ -1460,22 +897,3 @@ color-magnitude diagram.
 We used an isochrone to define a polygon and select stars we think are
 likely to be in GD-1.  Plotting the results, we have a clearer picture
 of GD-1, similar to Figure 1 in the original paper.
-
-## Best practices
-
-* Matplotlib provides operations for working with points, polygons,
-and other geometric entities, so it's not just for making figures.
-
-* Use Matplotlib options to control the size and aspect ratio of
-figures to make them easier to interpret.  In this example, we scaled
-the axes so the size of a degree is equal along both axes.
-
-* Record every element of the data analysis pipeline that would be
-needed to replicate the results.
-
-
-
-~~~
-
-~~~
-{: .language-python}

--- a/_episodes/07-plot.md
+++ b/_episodes/07-plot.md
@@ -3,27 +3,18 @@ title: "Visualization"
 teaching: 3000
 exercises: 0
 questions:
-
 - "How do we make a compelling visualization that tells a story?"
 
 objectives:
-
 - "Design a figure that tells a compelling story."
-
 - "Use Matplotlib features to customize the appearance of figures."
-
 - "Generate a figure with multiple subplots."
 
 keypoints:
-
 - "The most effective figures focus on telling a single story clearly."
-
 - "Consider using annotations to guide the reader's attention to the most important elements of a figure."
-
 - "The default Matplotlib style generates good quality figures, but there are several ways you can override the defaults."
-
 - "If you find yourself making the same customizations on several projects, you might want to create your own style sheet."
-
 ---
 
 {% include links.md %}
@@ -102,38 +93,34 @@ src="https://github.com/datacarpentry/astronomy-python/raw/gh-pages/fig/gd1-5.pn
 >
 > > ## Solution
 > > 
-> > ~~~
+> > Some topics that might come up in this discussion:
 > > 
-> > # Some topics that might come up in this discussion:
+> > 1. The primary result is that the multiple stages of selection 
+> > make it possible to separate likely candidates from the 
+> > background more effectively than in previous work, which makes 
+> > it possible to see the structure of GD-1 in "unprecedented detail".
 > > 
-> > # 1. The primary result is that the multiple stages of selection 
-> > # make it possible to separate likely candidates from the 
-> > # background more effectively than in previous work, which makes 
-> > # it possible to see the structure of GD-1 in "unprecedented detail".
+> > 2. The figure documents the selection process as a sequence of 
+> > steps.  Reading right-to-left, top-to-bottom, we see selection 
+> > based on proper motion, the results of the first selection, 
+> > selection based on color and magnitude, and the results of the 
+> > second selection.  So this figure documents the methodology and 
+> > presents the primary result.
 > > 
-> > # 2. The figure documents the selection process as a sequence of 
-> > # steps.  Reading right-to-left, top-to-bottom, we see selection 
-> > # based on proper motion, the results of the first selection, 
-> > # selection based on color and magnitude, and the results of the 
-> > # second selection.  So this figure documents the methodology and 
-> > # presents the primary result.
+> > 3. It's mostly black and white, with minimal use of color, so 
+> > it will work well in print.  The annotations in the bottom 
+> > left panel guide the reader to the most important results.  
+> > It contains enough technical detail for a professional audience, 
+> > but most of it is also comprehensible to a more general audience.  
+> > The two left panels have the same dimensions and their axes are 
+> > aligned.
 > > 
-> > # 3. It's mostly black and white, with minimal use of color, so 
-> > # it will work well in print.  The annotations in the bottom 
-> > # left panel guide the reader to the most important results.  
-> > # It contains enough technical detail for a professional audience, 
-> > # but most of it is also comprehensible to a more general audience.  
-> > # The two left panels have the same dimensions and their axes are 
-> > # aligned.
-> > 
-> > # 4. Since the panels represent a sequence, it might be better to 
-> > # arrange them left-to-right.  The placement and size of the axis 
-> > # labels could be tweaked.  The entire figure could be a little 
-> > # bigger to match the width and proportion of the caption.  
-> > # The top left panel has unnused white space (but that leaves 
-> > # space for the annotations in the bottom left).
-> > ~~~
-> > {: .language-python}
+> > 4. Since the panels represent a sequence, it might be better to 
+> > arrange them left-to-right.  The placement and size of the axis 
+> > labels could be tweaked.  The entire figure could be a little 
+> > bigger to match the width and proportion of the caption.  
+> > The top left panel has unnused white space (but that leaves 
+> > space for the annotations in the bottom left).
 > {: .solution}
 {: .challenge}
 
@@ -143,8 +130,6 @@ Let's start with the panel in the lower left.  You can [download the
 data from the previous
 lesson](https://github.com/AllenDowney/AstronomicalData/raw/main/data/gd1_data.hdf)
 or run the following cell, which downloads it if necessary.
-
-
 
 ~~~
 from os.path import basename, exists
@@ -163,8 +148,6 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 
 Now we can reload `winner_df`
 
-
-
 ~~~
 import pandas as pd
 
@@ -172,8 +155,6 @@ filename = 'gd1_data.hdf'
 winner_df = pd.read_hdf(filename, 'winner_df')
 ~~~
 {: .language-python}
-
-
 
 ~~~
 import matplotlib.pyplot as plt
@@ -194,8 +175,6 @@ def plot_second_selection(df):
 
 And here's what it looks like.
 
-
-
 ~~~
 plt.figure(figsize=(10,2.5))
 plot_second_selection(winner_df)
@@ -206,13 +185,8 @@ plot_second_selection(winner_df)
 <Figure size 1000x250 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](07-plot_files/07-plot_13_0.png)
-    
-
 
 ## Annotations
 
@@ -246,22 +220,21 @@ region of GD-1,
 > > ## Solution
 > > 
 > > ~~~
+> > plt.axvline(-55, ls='--', color='gray', 
+> >             alpha=0.4, dashes=(6,4), lw=2)
+> > plt.text(-60, 5.5, 'Previously\nundetected', 
+> >          fontsize='small', ha='right', va='top');
 > > 
-> > # plt.axvline(-55, ls='--', color='gray', 
-> > #             alpha=0.4, dashes=(6,4), lw=2)
-> > # plt.text(-60, 5.5, 'Previously\nundetected', 
-> > #          fontsize='small', ha='right', va='top');
+> > arrowprops=dict(color='gray', shrink=0.05, width=1.5, 
+> >                 headwidth=6, headlength=8, alpha=0.4)
 > > 
-> > # arrowprops=dict(color='gray', shrink=0.05, width=1.5, 
-> > #                 headwidth=6, headlength=8, alpha=0.4)
+> > plt.annotate('Spur', xy=(-33, 2), xytext=(-35, 5.5),
+> >              arrowprops=arrowprops,
+> >              fontsize='small')
 > > 
-> > # plt.annotate('Spur', xy=(-33, 2), xytext=(-35, 5.5),
-> > #              arrowprops=arrowprops,
-> > #              fontsize='small')
-> > 
-> > # plt.annotate('Gap', xy=(-22, -1), xytext=(-25, -5.5),
-> > #              arrowprops=arrowprops,
-> > #              fontsize='small')
+> > plt.annotate('Gap', xy=(-22, -1), xytext=(-25, -5.5),
+> >              arrowprops=arrowprops,
+> >              fontsize='small')
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -292,9 +265,10 @@ and `tick_params` to change the settings.
 
 Here's how you can put the ticks on the inside of the figure:
 
-```
+~~~
 plt.gca().tick_params(direction='in')
-```
+~~~
+{: .language-python}
 
 > ## Exercise
 > 
@@ -305,8 +279,7 @@ plt.gca().tick_params(direction='in')
 > > ## Solution
 > > 
 > > ~~~
-> > 
-> > # plt.gca().tick_params(top=True, right=True)
+> > plt.gca().tick_params(top=True, right=True)
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -319,8 +292,6 @@ notebook, you can use `rcParams`.
 
 Here's an example that reads the current font size from `rcParams`:
 
-
-
 ~~~
 plt.rcParams['font.size']
 ~~~
@@ -331,17 +302,7 @@ plt.rcParams['font.size']
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 And sets it to a new value:
-
-
 
 ~~~
 plt.rcParams['font.size'] = 14
@@ -370,8 +331,6 @@ Matplotlib provides a set of predefined style sheets, or you can make your own.
 
 The following cell displays a list of style sheets installed on your system.
 
-
-
 ~~~
 plt.style.available
 ~~~
@@ -393,28 +352,14 @@ plt.style.available
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 Note that `seaborn-paper`, `seaborn-talk` and `seaborn-poster` are
 particularly intended to prepare versions of a figure with text sizes
 and other features that work well in papers, talks, and posters.
 
 To use any of these style sheets, run `plt.style.use` like this:
 
-```
-plt.style.use('fivethirtyeight')
-```
-
-
-
 ~~~
-
+plt.style.use('fivethirtyeight')
 ~~~
 {: .language-python}
 
@@ -435,8 +380,6 @@ You can [download the style
 sheet](https://github.com/AllenDowney/AstronomicalData/raw/main/az-paper-twocol.mplstyle)
 or run the following cell, which downloads it if necessary.
 
-
-
 ~~~
 download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
          'az-paper-twocol.mplstyle')
@@ -445,33 +388,21 @@ download('https://github.com/AllenDowney/AstronomicalData/raw/main/' +
 
 You can use it like this:
 
-```
-plt.style.use('./az-paper-twocol.mplstyle')
-```
-
-The prefix `./` tells Matplotlib to look for the file in the current directory.
-
-
-
 ~~~
-
+plt.style.use('./az-paper-twocol.mplstyle')
 ~~~
 {: .language-python}
+
+The prefix `./` tells Matplotlib to look for the file in the current directory.
 
 As an alternative, you can install a style sheet for your own use by
 putting it in your configuration directory.  To find out where that
 is, you can run the following command:
 
-```
+~~~
 import matplotlib as mpl
 
 mpl.get_configdir()
-```
-
-
-
-~~~
-
 ~~~
 {: .language-python}
 
@@ -489,17 +420,17 @@ customize Matplotlib to use LaTeX.
 
 In `matplotlibrc` or in a style sheet, you can add the following line:
 
-```
+~~~
 text.usetex        : true
-```
+~~~
+{: .language-python}
 
 Or in a notebook you can run the following code.
 
-```
+~~~
 plt.rcParams['text.usetex'] = True
-```
-
-
+~~~
+{: .language-python}
 
 ~~~
 plt.rcParams['text.usetex'] = True
@@ -508,24 +439,25 @@ plt.rcParams['text.usetex'] = True
 
 If you go back and draw the figure again, you should see the difference.
 
-If you get an error message like
-
-```
-LaTeX Error: File `type1cm.sty' not found.
-```
-
-You might have to install a package that contains the fonts LaTeX
-needs.  On some systems, the packages `texlive-latex-extra` or
-`cm-super` might be what you need.  [See here for more help with
-this](https://stackoverflow.com/questions/11354149/python-unable-to-render-tex-in-matplotlib).
-
-In case you are curious, `cm` stands for [Computer
-Modern](https://en.wikipedia.org/wiki/Computer_Modern), the font LaTeX
-uses to typeset math.
+> ## Warning
+> If you get an error message like
+> 
+> ~~~
+> LaTeX Error: File `type1cm.sty' not found.
+> ~~~
+> {: .language-python}
+> 
+> You might have to install a package that contains the fonts LaTeX
+> needs.  On some systems, the packages `texlive-latex-extra` or
+> `cm-super` might be what you need.  [See here for more help with
+> this](https://stackoverflow.com/questions/11354149/python-unable-to-render-tex-in-matplotlib).
+> 
+> In case you are curious, `cm` stands for [Computer
+> Modern](https://en.wikipedia.org/wiki/Computer_Modern), the font LaTeX
+> uses to typeset math.
+{: .error}
 
 Before we go on, let's put things back where we found them.
-
-
 
 ~~~
 plt.rcParams['text.usetex'] = False
@@ -564,8 +496,6 @@ generates each panel in a function.
 
 To make the panel in the upper right, we have to reload `centerline_df`.
 
-
-
 ~~~
 filename = 'gd1_data.hdf'
 centerline_df = pd.read_hdf(filename, 'centerline_df')
@@ -573,8 +503,6 @@ centerline_df = pd.read_hdf(filename, 'centerline_df')
 {: .language-python}
 
 And define the coordinates of the rectangle we selected.
-
-
 
 ~~~
 pm1_min = -8.9
@@ -593,8 +521,6 @@ To plot this rectangle, we'll use a feature we have not seen before:
 To create a `Polygon`, we have to put the coordinates in an array with
 `x` values in the first column and `y` values in the second column.
 
-
-
 ~~~
 import numpy as np
 
@@ -611,19 +537,9 @@ array([[-8.9, -2.2],
 ~~~
 {: .output}
 
-
-
-
-
-    
-
-
-
 The following function takes a `DataFrame` as a parameter, plots the
 proper motion for each star, and adds a shaded `Polygon` to show the
 region we selected.
-
-
 
 ~~~
 from matplotlib.patches import Polygon
@@ -652,8 +568,6 @@ we have to use `gca` to get the current axes.
 Here's what the new version of the figure looks like.  We've changed
 the labels on the axes to be consistent with the paper.
 
-
-
 ~~~
 plot_proper_motion(centerline_df)
 ~~~
@@ -663,19 +577,12 @@ plot_proper_motion(centerline_df)
 <Figure size 640x480 with 1 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](07-plot_files/07-plot_53_0.png)
-    
-
 
 ## Upper left
 
 Now let's work on the panel in the upper left. We have to reload `candidates`.
-
-
 
 ~~~
 filename = 'gd1_data.hdf'
@@ -685,8 +592,6 @@ candidate_df = pd.read_hdf(filename, 'candidate_df')
 
 Here's a function that takes a `DataFrame` of candidate stars and
 plots their positions in GD-1 coordindates.
-
-
 
 ~~~
 def plot_first_selection(df):
@@ -705,8 +610,6 @@ def plot_first_selection(df):
 
 And here's what it looks like.
 
-
-
 ~~~
 plot_first_selection(candidate_df)
 ~~~
@@ -716,20 +619,13 @@ plot_first_selection(candidate_df)
 <Figure size 640x480 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](07-plot_files/07-plot_59_0.png)
-    
-
 
 ## Lower right
 
 For the figure in the lower right, we'll use this function to plots
 the color-magnitude diagram.
-
-
 
 ~~~
 import matplotlib.pyplot as plt
@@ -755,8 +651,6 @@ def plot_cmd(table):
 
 Here's what it looks like.
 
-
-
 ~~~
 plot_cmd(candidate_df)
 ~~~
@@ -766,17 +660,10 @@ plot_cmd(candidate_df)
 <Figure size 640x480 with 1 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](07-plot_files/07-plot_63_0.png)
-    
-
 
 And here's how we read it back.
-
-
 
 ~~~
 filename = 'gd1_data.hdf'
@@ -795,64 +682,6 @@ loop_df.head()
 ~~~
 {: .output}
 
-
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>color_loop</th>
-      <th>mag_loop</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>0.632171</td>
-      <td>21.411746</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>0.610238</td>
-      <td>21.322466</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>0.588449</td>
-      <td>21.233380</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>0.566924</td>
-      <td>21.144427</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>0.545461</td>
-      <td>21.054549</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
 > ## Exercise
 > 
 > Add a few lines to `plot_cmd` to show the polygon we selected as a
@@ -863,10 +692,9 @@ loop_df.head()
 > > ## Solution
 > > 
 > > ~~~
-> > 
-> > # poly = Polygon(loop_df, closed=True, 
-> > #                facecolor='C1', alpha=0.4)
-> > # plt.gca().add_patch(poly)
+> > poly = Polygon(loop_df, closed=True, 
+> >               facecolor='C1', alpha=0.4)
+> > plt.gca().add_patch(poly)
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -889,8 +717,6 @@ For the first panel, `loc` is `(0, 0)`, which indicates row 0 and
 column 0, which is the upper-left panel.
 
 Here's how we use it to draw the four panels.
-
-
 
 ~~~
 shape = (2, 2)
@@ -917,13 +743,8 @@ plt.tight_layout()
 <Figure size 640x480 with 4 Axes>
 ~~~
 {: .output}
-
-
-
-    
+   
 ![png](07-plot_files/07-plot_69_0.png)
-    
-
 
 We use
 [`plt.tight_layout`](https://matplotlib.org/3.3.1/tutorials/intermediate/tight_layout_guide.html)
@@ -948,8 +769,6 @@ wider than the panels on the right.
 
 At the same time, we use `figsize` to adjust the aspect ratio of the
 whole figure.
-
-
 
 ~~~
 plt.figure(figsize=(9, 4.5))
@@ -978,13 +797,8 @@ plt.tight_layout()
 <Figure size 900x450 with 4 Axes>
 ~~~
 {: .output}
-
-
-
     
 ![png](07-plot_files/07-plot_72_0.png)
-    
-
 
 This is looking more and more like the figure in the paper.
 
@@ -997,25 +811,25 @@ This is looking more and more like the figure in the paper.
 > > 
 > > ~~~
 > > 
-> > # plt.figure(figsize=(9, 4.5))
+> > plt.figure(figsize=(9, 4.5))
 > > 
-> > # shape = (2, 5)                                   # CHANGED
-> > # plt.subplot2grid(shape, (0, 0), colspan=3)
-> > # plot_first_selection(candidate_df)
+> > shape = (2, 5)                                   # CHANGED
+> > plt.subplot2grid(shape, (0, 0), colspan=3)
+> > plot_first_selection(candidate_df)
 > > 
-> > # plt.subplot2grid(shape, (0, 3), colspan=2)       # CHANGED
-> > # plot_proper_motion(centerline_df)
+> > plt.subplot2grid(shape, (0, 3), colspan=2)       # CHANGED
+> > plot_proper_motion(centerline_df)
 > > 
-> > # plt.subplot2grid(shape, (1, 0), colspan=3)
-> > # plot_second_selection(winner_df)
+> > plt.subplot2grid(shape, (1, 0), colspan=3)
+> > plot_second_selection(winner_df)
 > > 
-> > # plt.subplot2grid(shape, (1, 3), colspan=2)       # CHANGED
-> > # plot_cmd(candidate_df)
-> > # poly = Polygon(coords, closed=True, 
-> > #                facecolor='C1', alpha=0.4)
-> > # plt.gca().add_patch(poly)
+> > plt.subplot2grid(shape, (1, 3), colspan=2)       # CHANGED
+> > plot_cmd(candidate_df)
+> > poly = Polygon(coords, closed=True, 
+> >                facecolor='C1', alpha=0.4)
+> > plt.gca().add_patch(poly)
 > > 
-> > # plt.tight_layout()
+> > plt.tight_layout()
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -1031,24 +845,3 @@ We explored features Matplotlib provides for adding annotations to
 figures -- including text, lines, arrows, and polygons -- and several
 ways to customize the appearance of figures.  And we learned how to
 create figures that contain multiple panels.
-
-## Best practices
-
-* The most effective figures focus on telling a single story clearly
-and compellingly.
-
-* Consider using annotations to guide the reader's attention to the
-most important elements of a figure.
-
-* The default Matplotlib style generates good quality figures, but
-there are several ways you can override the defaults.
-
-* If you find yourself making the same customizations on several
-projects, you might want to create your own style sheet.
-
-
-
-~~~
-
-~~~
-{: .language-python}


### PR DESCRIPTION
- remove extraneous blank lines
- move "best practices" to keypoints
- move code that generates errors to `{: .error}` chunks
- remove duplicate table output
- remove comment characters from code in exercise solutions
- add formatting for exercises where missing