### PR TITLE
changing query_cone to cone_query

### DIFF
--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -217,7 +217,7 @@ Here is how we run it:
 ~~~
 from astroquery.gaia import Gaia
 
-cone_job = Gaia.launch_job(query_cone)
+cone_job = Gaia.launch_job(cone_query)
 cone_job
 ~~~
 {: .language-python}


### PR DESCRIPTION
This fixes issue #70. I also ran a grep on the episode files to make sure that this is the only location that query_cone is being used and checked that it wasn't a subtle variable redefinition.