### PR TITLE
moving on the fly column creation to the astropy table rather than th…

### DIFF
--- a/student_download/episode_functions.py
+++ b/student_download/episode_functions.py
@@ -53,14 +53,15 @@ def make_dataframe(table):
     # Correct GD-1 coordinates for solar system motion around galactic center
     skycoord_gd1 = reflex_correct(transformed)
 
+    #Add GD-1 reference frame columns for coordinates and proper motions
+    table['phi1'] = skycoord_gd1.phi1
+    table['phi2'] = skycoord_gd1.phi2
+    table['pm_phi1'] = skycoord_gd1.pm_phi1_cosphi2
+    table['pm_phi2'] = skycoord_gd1.pm_phi2
+
     # Create DataFrame
     df = table.to_pandas()
 
-    #Add GD-1 reference frame columns for coordinates and proper motions
-    df['phi1'] = skycoord_gd1.phi1
-    df['phi2'] = skycoord_gd1.phi2
-    df['pm_phi1'] = skycoord_gd1.pm_phi1_cosphi2
-    df['pm_phi2'] = skycoord_gd1.pm_phi2
     return df
 
 def plot_proper_motion(df):


### PR DESCRIPTION
@jdeplaa reports the following error when running on Mac OS

```
results_df = make_dataframe(polygon_results)
results_df.describe()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/miniconda2/envs/AstronomicalData/lib/python3.9/site-packages/astropy/units/quantity.py in _to_own_unit(self, value, check_precision)
   1346         try:
-> 1347             _value = value.to_value(self.unit)
   1348         except AttributeError:
AttributeError: 'numpy.ndarray' object has no attribute 'to_value'
```

I have determined the following about this error:
* it doesn't occur on the DataFrame until after we've added the new columns (so it isn't an astropy issue - it has something to do with how Pandas handles mixins when a column is added on the fly)
* if you pull out the series (e.g. `x = results_df['phi1']`) it doesn't have this issue
* it doesn't occur in Pandas 1.2.5 - so it was introduced in 1.3.0

Given all of this, I believe the simplest solution is to add the columns to the astropy table prior to converting to a DataFrame. I've implemented this change in episode 3 where we prototype and build the `make_dataframe` function and in `episode_functions.py` where we import `make_dataframe` in subsequent lessons. I also checked that `to_pandas` doesn't occur in any other episodes (yay functions!)