### PR TITLE
modifying language around combining polygon_results and skycoord_gd1

### DIFF
--- a/_episodes/03-motion.md
+++ b/_episodes/03-motion.md
@@ -480,8 +480,8 @@ transformed back to the GD-1 frame, it is a rectangle again.
 
 ## Pandas DataFrame
 
-At this point we have two objects containing different subsets of the
-data.  `polygon_results` is the Astropy `Table` we downloaded from Gaia.
+At this point we have two objects containing different sets of the
+data relating to identifying stars in GD-1.  `polygon_results` is the Astropy `Table` we downloaded from Gaia.
 
 ~~~
 type(polygon_results)


### PR DESCRIPTION
I changes `subset` --> `set`. I think the purpose of the subset language is to imply that these are related datasets, so I added a few words at the end to keep this intent.