### PR TITLE
fixing number of columns in results_df output

### DIFF
--- a/_episodes/03-motion.md
+++ b/_episodes/03-motion.md
@@ -612,7 +612,7 @@ results_df.shape
 {: .language-python}
 
 ~~~
-(140339, 6)
+(140339, 10)
 ~~~
 {: .output}
 


### PR DESCRIPTION
Very minor change for output of shape to reflect columns added before making the data frame