### PR TITLE
Fix formatting error

### DIFF
--- a/_episodes/08-plot.md
+++ b/_episodes/08-plot.md
@@ -689,7 +689,7 @@ ax.add_patch(poly)
 > >  {: .output}
 > >     
 > > ![Four paneled plot we created above with two left-hand panels increased in width.](../fig/08-plot_files/08-plot_72_0.png)
-> {.solution}
+> {: .solution}
 {: .challenge}
 
 ## Summary


### PR DESCRIPTION
The solution tag was not recognised because it needed the `:` after the `{`. I found this because it was a problem with the pegboard parser.
