### PR TITLE
rename skycoord_to_string to something more accurate and descriptive

### DIFF
--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -607,7 +607,7 @@ def skycoord_to_string(skycoord):
 Here is how we use this function:
 
 ~~~
-sky_point_list = polygon_skycoord_to_gaia_string(corners_icrs)
+sky_point_list = skycoord_to_string(corners_icrs)
 sky_point_list
 ~~~
 {: .language-python}

--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -596,7 +596,7 @@ This is something we will need to do multiple times. We will write a function to
 The following function combines these steps. 
 
 ~~~
-def polygon_skycoord_to_gaia_string(skycoord):
+def skycoord_to_string(skycoord):
     """Convert a one-dimenstional list of SkyCoord to string for Gaia's query format."""
     corners_list_str = skycoord.to_string()
     corners_single_str = ' '.join(corners_list_str)

--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -596,8 +596,8 @@ This is something we will need to do multiple times. We will write a function to
 The following function combines these steps. 
 
 ~~~
-def skycoord_to_string(skycoord):
-    """Convert SkyCoord to string."""
+def polygon_skycoord_to_gaia_string(skycoord):
+    """Convert a one-dimenstional list of SkyCoord to string for Gaia's query format."""
     corners_list_str = skycoord.to_string()
     corners_single_str = ' '.join(corners_list_str)
     return corners_single_str.replace(' ', ', ')
@@ -607,7 +607,7 @@ def skycoord_to_string(skycoord):
 Here is how we use this function:
 
 ~~~
-sky_point_list = skycoord_to_string(corners_icrs)
+sky_point_list = polygon_skycoord_to_gaia_string(corners_icrs)
 sky_point_list
 ~~~
 {: .language-python}

--- a/student_download/episode_functions.py
+++ b/student_download/episode_functions.py
@@ -19,7 +19,7 @@ def make_rectangle(x1, x2, y1, y2):
     return xs, ys
 
 def skycoord_to_string(skycoord):
-    """Convert SkyCoord to string."""
+    """Convert a one-dimenstional list of SkyCoord to string for Gaia's query format."""
     t = skycoord.to_string()
     s = ' '.join(t)
     return s.replace(' ', ', ')


### PR DESCRIPTION
 “skycoord_to_string” is poorly named because it’s not for converting SkyCoord’s *in general* into strings, but rather length-4 SkyCoords into the right kind of list for the query.  So I’d suggest this renaming.