### PR TITLE
changing unit that breaks the conversions to something less confusing

### DIFF
--- a/_episodes/02-coords.md
+++ b/_episodes/02-coords.md
@@ -151,7 +151,7 @@ If the units are not compatible, you get an error.
 For example:
 
 ```
-angle + 5 * u.second
+angle + 5 * u.kg
 ```
 {: .error}
 


### PR DESCRIPTION
This episode creates an angle in degrees and then shows that you can't add different units together using the units of seconds, which is really easy to mistake for arc seconds. This changes it to kilograms to make it clear that you can add angles to masses.