### PR TITLE
Remove pm polygon

### DIFF
--- a/_episodes/05-select.md
+++ b/_episodes/05-select.md
@@ -195,7 +195,6 @@ In the following exercise, we will identify a rectangle that encompasses the maj
 > > pmra_max = -3
 > > pmdec_min = -14.31
 > > pmdec_max = -11.2
-> > """
 > > ~~~
 > > {: .language-python}
 > {: .solution}

--- a/_episodes/07-photo.md
+++ b/_episodes/07-photo.md
@@ -66,7 +66,6 @@ main sequence of GD-1 from mostly younger background stars.
 > > from os.path import getsize
 > > 
 > > import pandas as pd
-> > import numpy as np
 > > 
 > > from matplotlib import pyplot as plt
 > > 
@@ -368,6 +367,7 @@ To combine the `left_color` and `right_color` arrays we will use the NumPy `appe
 which takes two arrays as input, and outputs them combined into a single array.
 
 ~~~
+import numpy as np
 color_loop = np.append(left_color, reverse_right_color)
 color_loop.shape
 ~~~


### PR DESCRIPTION
The ADQL `POLYGON` function is intended to be used only on coordinates. A recent release enforced this by limiting the first value (RA) to be positive. Our previous lessons used `POLYGON` to select a region in proper motion space where the proper motion in RA was negative. The current lesson introduces a hack which puts the negative sign inside the `POINT` function, but this is not generalizable to any proper motion query. This PR replaces the POLYGON proper motion call with two `BETWEEN` statements (for `pmra` and `pmdec`). This produces a slightly different sample, but similar enough that it is hard to distinguish in figures (I have not updated these) and isn't hugely different in size. As a result of this switch, the convex hull section is removed and the `pm_point_list` is replaced with `pmra_min`, `pmra_max`, `pmdec_min`, and `pmdec_max`. This PR also fixes issue #132 

A new version of student_download.zip should be uploaded to figshare approximately concurrent with this PR 