### PR TITLE
Minor join episode fixes

### DIFF
--- a/_episodes/06-join.md
+++ b/_episodes/06-join.md
@@ -166,7 +166,7 @@ Before we get to the `JOIN` operation, we will explore these tables.
 Here is the metadata for `panstarrs1_best_neighbour`.
 
 ~~~
-ps_best_neighbor_meta = Gaia.load_table('gaiadr2.panstarrs1_best_neighbour')
+ps_best_neighbour_meta = Gaia.load_table('gaiadr2.panstarrs1_best_neighbour')
 ~~~
 {: .language-python}
 
@@ -178,7 +178,7 @@ Done.
 {: .output}
 
 ~~~
-print(ps_best_neighbor_meta)
+print(ps_best_neighbour_meta)
 ~~~
 {: .language-python}
 
@@ -195,7 +195,7 @@ Num. columns: 7
 And here are the columns.
 
 ~~~
-for column in ps_best_neighbor_meta.columns:
+for column in ps_best_neighbour_meta.columns:
     print(column.name)
 ~~~
 {: .language-python}
@@ -235,7 +235,7 @@ source in Gaia and the corresponding source in Pan-STARRS.
 Here is a query that selects these columns and returns the first 5 rows.
 
 ~~~
-ps_best_neighbor_query = """SELECT 
+ps_best_neighbour_query = """SELECT 
 TOP 5
 source_id, best_neighbour_multiplicity, number_of_mates, original_ext_source_id
 FROM gaiadr2.panstarrs1_best_neighbour
@@ -244,7 +244,7 @@ FROM gaiadr2.panstarrs1_best_neighbour
 {: .language-python}
 
 ~~~
-ps_best_neighbor_job = Gaia.launch_job_async(query=ps_best_neighbor_query)
+ps_best_neighbour_job = Gaia.launch_job_async(query=ps_best_neighbour_query)
 ~~~
 {: .language-python}
 
@@ -254,8 +254,8 @@ INFO: Query finished. [astroquery.utils.tap.core]
 {: .output}
 
 ~~~
-ps_best_neighbor_results = ps_best_neighbor_job.get_results()
-ps_best_neighbor_results
+ps_best_neighbour_results = ps_best_neighbour_job.get_results()
+ps_best_neighbour_results
 ~~~
 {: .language-python}
 
@@ -406,7 +406,7 @@ If you are curious, you can [read more about
 it](https://chartio.com/learn/databases/how-does-indexing-work/).
 
 <img
-src="../fig/join.png" alt="Diagram showing relationship between the gaia_source, panstarrs1_best_neighbor, and panstarrs1_original_valid tables and result table.">
+src="../fig/join.png" alt="Diagram showing relationship between the gaia_source, panstarrs1_best_neighbour, and panstarrs1_original_valid tables and result table.">
 
 Now we will get to the details of performing a `JOIN` operation.
 
@@ -549,7 +549,7 @@ column from the Gaia table with the `source_id` column from the best
 neighbor table.
 
 ~~~
-neighbors_base_query = """SELECT 
+neighbours_base_query = """SELECT 
 {columns}
 FROM gaiadr2.gaia_source AS gaia
 JOIN gaiadr2.panstarrs1_best_neighbour AS best
@@ -597,8 +597,8 @@ column_list_neighbours = ['gaia.source_id',
               ]
 columns = ', '.join(column_list_neighbours)
 
-neighbors_query = neighbors_base_query.format(columns=columns)
-print(neighbors_query)
+neighbours_query = neighbours_base_query.format(columns=columns)
+print(neighbours_query)
 ~~~
 {: .language-python}
 
@@ -615,7 +615,7 @@ WHERE 1=CONTAINS(
 {: .output}
 
 ~~~
-neighbors_job = Gaia.launch_job_async(neighbors_query)
+neighbours_job = Gaia.launch_job_async(neighbours_query)
 ~~~
 {: .language-python}
 
@@ -625,8 +625,8 @@ INFO: Query finished. [astroquery.utils.tap.core]
 {: .output}
 
 ~~~
-neighbors_results = neighbors_job.get_results()
-neighbors_results
+neighbours_results = neighbours_job.get_results()
+neighbours_results
 ~~~
 {: .language-python}
 
@@ -958,7 +958,7 @@ All values in this column are `0`, which means that for each match we
 found in Pan-STARRS, there are no other stars in Gaia that also match.
 
 > ## Number of neighbors
-> The table also contains `number_of_neighbors` which is the
+> The table also contains `number_of_neighbours` which is the
 > number of stars in Pan-STARRS that match in terms of position, before
 > using other criteria to choose the most likely match.  But we are more
 > interested in the final match, using both criteria.

--- a/_episodes/06-join.md
+++ b/_episodes/06-join.md
@@ -244,7 +244,7 @@ FROM gaiadr2.panstarrs1_best_neighbour
 {: .language-python}
 
 ~~~
-ps_best_neighbour_job = Gaia.launch_job_async(query=ps_best_neighbour_query)
+ps_best_neighbour_job = Gaia.launch_job_async(ps_best_neighbour_query)
 ~~~
 {: .language-python}
 
@@ -357,7 +357,7 @@ FROM gaiadr2.panstarrs1_original_valid
 {: .language-python}
 
 ~~~
-ps_valid_job = Gaia.launch_job_async(query=ps_valid_query)
+ps_valid_job = Gaia.launch_job_async(ps_valid_query)
 ~~~
 {: .language-python}
 
@@ -430,7 +430,7 @@ WHERE 1=CONTAINS(
 And we will run it, to make sure we have a working query to build on.
 
 ~~~
-test_cone_job = Gaia.launch_job(query=test_cone_query)
+test_cone_job = Gaia.launch_job(test_cone_query)
 ~~~
 {: .language-python}
 
@@ -499,7 +499,7 @@ WHERE 1=CONTAINS(
 We run the query again.
 
 ~~~
-cone_job = Gaia.launch_job_async(query=cone_query)
+cone_job = Gaia.launch_job_async(cone_query)
 ~~~
 {: .language-python}
 
@@ -786,7 +786,7 @@ WHERE parallax < 1
 We run it to make sure we are starting with a working query.
 
 ~~~
-candidate_coord_pm_job = Gaia.launch_job_async(query=candidate_coord_pm_query)
+candidate_coord_pm_job = Gaia.launch_job_async(candidate_coord_pm_query)
 ~~~
 {: .language-python}
 
@@ -857,7 +857,7 @@ candidate_coord_pm_results
 > > print(candidate_join_query)
 > > 
 > > 
-> > candidate_join_job = Gaia.launch_job_async(query=candidate_join_query)
+> > candidate_join_job = Gaia.launch_job_async(candidate_join_query)
 > > candidate_table = candidate_join_job.get_results()
 > > candidate_table
 > > ~~~

--- a/_episodes/06-join.md
+++ b/_episodes/06-join.md
@@ -1034,22 +1034,6 @@ getsize('gd1_data.csv') / MB
 ~~~
 {: .output}
 
-We can see the first few lines like this:
-
-~~~
-head('gd1_data.csv')
-~~~
-{: .language-python}
-
-~~~
-,source_id,ra,dec,pmra,pmdec,best_neighbour_multiplicity,number_of_mates,g_mean_psf_mag,i_mean_psf_mag,phi1,phi2,pm_phi1,pm_phi2 
-0,635860218726658176,138.5187065217173,19.09233926905897,-5.941679495793577,-11.346409129876392,1,0,17.8978004455566,17.5174007415771,-59.247329893833296,-2.016078400820631,-7.527126084640531,1.7487794924176672
-
-1,635674126383965568,138.8428741026386,19.031798198627634,-3.8970011609340207,-12.702779525389634,1,0,19.2873001098633,17.6781005859375,-59.13339098769217,-2.306900745179831,-7.560607655557415,-0.7417999555980248
-~~~
-{: .output}  
-The CSV file contains the names of the columns, but not the data types.
-
 We can read the CSV file back like this:
 
 ~~~
@@ -1101,7 +1085,8 @@ read_back_csv.head(3)
 ~~~
 {: .output}
 
-Notice that the index in `candidate_df` has become an unnamed column
+The CSV file contains the names of the columns, but not the data types.
+Additionally, notice that the index in `candidate_df` has become an unnamed column
 in `read_back_csv` and a new index has been created.  The Pandas functions for writing and reading CSV
 files provide options to avoid that problem, but this is an example of
 the kind of thing that can go wrong with CSV files.


### PR DESCRIPTION
This PR tweaks to JOIN lesson to streamline the teaching:
* all code uses British spelling of neighbours so learners don't have to switch between spellings mid line
* removed `query=` syntax from `launch_job_async` to be consistent with the rest of the episodes
* removed reference to the` head` function which doesn't exist any more