### PR TITLE
Issue160 - Callout box explaining PerformanceWarning

### DIFF
--- a/_episodes/05-select.md
+++ b/_episodes/05-select.md
@@ -464,6 +464,23 @@ point_series.to_hdf(filename, 'point_series')
 ~~~
 {: .language-python}
 
+> ## Performance Warning
+> You may see the previous command issue this or a similar performance warning:
+>
+> ~~~
+> [...] PerformanceWarning:
+> your performance may suffer as PyTables will pickle object types that it cannot
+> map directly to c-types [inferred_type->mixed-integer,key->values] [items->None]
+>   point_series.to_hdf(filename, 'point_series')
+> ~~~
+> {: .output}
+> This is because in the Series we just created, we are mixing variables of
+> different types: `sky_point_list` is a string (text), whereas `pmra_min`
+> etc. are floating point numbers. While combining different data types in a
+> single Series is somewhat inefficient, the amount of data is small enough to
+> not matter in this case, so this warning can be safely ignored.
+{: .callout}
+
 ## Plotting one more time
 
 Now we can examine the results:


### PR DESCRIPTION
Added a callout box giving the output of the point_series.to_hdf(filename, 'point_series') command, explaining where the Warning comes from and why it can be ignored. 
This closes issue #160. 