### PR TITLE
add Zenodo JSON for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,50 @@
+{
+  "contributors": [
+    {
+      "type": "Editor",
+      "name": "K. Azalee Bostroem",
+      "orcid": "0000-0002-4924-444X"
+    },
+    {
+      "type": "Editor",
+      "name": "Rodolfo Montez Jr.",
+      "orcid": "0000-0002-6752-2909"
+    },
+    {
+      "type": "Editor",
+      "name": "David DeMuth"
+    },
+    {
+      "type": "Editor",
+      "name": "Ralf Kotulla",
+      "orcid": "0000-0002-4460-9892"
+    }
+  ],
+  "creators": [
+    {
+      "name": "K. Azalee Bostroem",
+      "orcid": "0000-0002-4924-444X"
+    },
+    {
+      "name": "Ralf Kotulla",
+      "orcid": "0000-0002-4460-9892"
+    },
+    {
+      "name": "Adam Hughes"
+    },
+    {
+      "name": "Rodolfo Montez Jr.",
+      "orcid": "0000-0002-6752-2909"
+    },
+    {
+      "name": "Catherine Martlin",
+      "orcid": "0000-0002-3300-4185"
+    },
+    {
+      "name": "rlucas-scninet"
+    }
+  ],
+  "license": {
+    "id": "CC-BY-4.0"
+  }
+}


### PR DESCRIPTION
This adds a `.zenodo.json` file containing metadata about lesson contributors since [the previous release](https://zenodo.org/record/6419749#.ZFtG2HZBy2o).

Since a `.zenodo.json` file was not present before, I guess the first release was made manually and releasing with this file merged may result in a new Zenodo record being created, rather than a new version being added to the existing record. If so, we will need to come back and adjust the README, and add a note to each record to point people in the right direction to find all releases.