### PR TITLE
Changes typo in solution axis -> axes solves issue #201

### DIFF
--- a/episodes/08-plot.md
+++ b/episodes/08-plot.md
@@ -364,7 +364,7 @@ ax.tick_params(top=True, right=True)
 # Looking up the 'axes.edgecolor' rcParams value
 print(plt.rcParams['axes.edgecolor'])
 
-plt.rcParams['axis.edgecolor'] = 'red'
+plt.rcParams['axes.edgecolor'] = 'red'
 
 fig = plt.figure(figsize=(10,2.5))
 ax = fig.add_subplot(1,1,1)


### PR DESCRIPTION
In this PR I fixed the typo in the solution to [this exercise](https://datacarpentry.org/astronomy-python/08-plot.html#exercise-5-minutes-1) of episode [Visualization](https://github.com/datacarpentry/astronomy-python/blob/main/episodes/08-plot.md).

This was reported in issue #201.

Indeed the good syntax is `plt.rcParams['axes.edgecolor'] = 'red'` instead of `plt.rcParams['axis.edgecolor'] = 'red'`, note typo chaning `i` for `e`.

