### PR TITLE
switching solution tag to spoiler tag for collapsable text that isn't…

### DIFF
--- a/episodes/03-transform.md
+++ b/episodes/03-transform.md
@@ -52,7 +52,7 @@ analysis, identifying stars with the proper motion we expect for GD-1.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 

--- a/episodes/04-motion.md
+++ b/episodes/04-motion.md
@@ -49,7 +49,7 @@ analysis, identifying stars with the proper motion we expect for GD-1.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 

--- a/episodes/05-select.md
+++ b/episodes/05-select.md
@@ -51,7 +51,7 @@ single query.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 

--- a/episodes/06-join.md
+++ b/episodes/06-join.md
@@ -61,7 +61,7 @@ main sequence of GD-1 from younger background stars.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 

--- a/episodes/07-photo.md
+++ b/episodes/07-photo.md
@@ -58,7 +58,7 @@ main sequence of GD-1 from mostly younger background stars.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 
@@ -120,7 +120,7 @@ and i filters, which indicates color.
 If you are wondering (as a non-domain expert)
 how to interpret this color-magnitude diagram, please expand the section below.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## The color magnitude diagram of GD-1 and foreground stars
 

--- a/episodes/08-plot.md
+++ b/episodes/08-plot.md
@@ -49,7 +49,7 @@ them to make a figure that tells a compelling scientific story.
 If you are starting a new notebook for this episode, expand this section
 for information you will need to get started.
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Read me
 


### PR DESCRIPTION
In this lesson we have a few places where the solution tag is used to create collapsable text at the starting from this episode sections and the explanation of a CMD diagram. This formatting doesn't work with the new lesson format and creates overlapping text. The correct tag to use is `spoiler`. This PR updates these instances from `solution` to `spoiler`