### PR TITLE
Update 02-coords.md

### DIFF
--- a/episodes/02-coords.md
+++ b/episodes/02-coords.md
@@ -390,7 +390,7 @@ Gala provides
 [`GD1Koposov10`](https://gala-astro.readthedocs.io/en/latest/_modules/gala/coordinates/gd1.html),
 which is "a Heliocentric spherical coordinate system defined by the
 orbit of the GD-1 stream". In this coordinate system, one axis is defined along
-the direction of the steam (the x-axis in Figure 1) and one axis is defined
+the direction of the stream (the x-axis in Figure 1) and one axis is defined
 perpendicular to the direction of the stream (the y-axis in Figure 1).
 These are called the φ<sub>1</sub> and φ<sub>2</sub> coordinates, respectively.
 


### PR DESCRIPTION
Incorrect word "steam" changed to the intended word "stream"

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
NA

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

There was an incorrect word in a caption of a figure. Instead of "direction of the steam", the correct word to use is "stream" since the figure is showing a stream of stars.

_If any relevant discussions have taken place elsewhere, please provide links to these._
NA

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
