### PR TITLE
Update setup instructions for Python

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -31,13 +31,12 @@ You will need to install Python, Jupyter, and some additional libraries.
 [Python](https://python.org) is a popular language for
 scientific computing, and great for general-purpose programming as
 well. For this workshop we use Python version 3.x.
-Installing all of its scientific packages individually can be
-a bit difficult, so we recommend an all-in-one installer.
-We will use Anaconda.
+Installing all of its scientific packages individually can be a bit difficult, so we provide an environment file to help you take care of them all together.
+We will use the _Miniforge_ distribution of Python.
 
 ### Anaconda
 
-Download and install [Anaconda](https://www.anaconda.com/download).
+Download and install [MiniForge](https://conda-forge.org/download/).
 
 To create a new Conda environment, which includes the additional packages we will be using
 in this workshop, you will need the environment file (`environment.yml`) you downloaded in the data section.


### PR DESCRIPTION
This updates the setup instructions for Python workshops. [A recent blog post provides more context for this change](https://carpentries.org/blog/2025/03/lesson-setup-instructions-task-force-recommendations/). Specifically, this PR updates the instructions to reflect that we recommend Miniforge instead of Anaconda Python. 

The previous setup instructions were fairly minimal, directing learners to install Anaconda and assuming that (with some experience working with Python) they will know how to do this. I guess a lot of learners may already have their own Python setup that they're happy with too. So I have not expanded the instructions to discuss the install steps in detail. 

Please let me know if you think some more verbose guidance is needed and I can update.