### PR TITLE
Update 01-query.md

### DIFF
--- a/episodes/01-query.md
+++ b/episodes/01-query.md
@@ -675,9 +675,9 @@ In this example, the WHERE clause is in the wrong place.
 ```error
 query2_erroneous = """SELECT 
 TOP 3000
-WHERE parallax < 1
-source_id, ref_epoch, ra, dec, parallax
+source_id, ra, dec, pmra, pmdec, parallax
 FROM gaiadr2.gaia_source
+WHERE parallax < 1
 """
 ```
 


### PR DESCRIPTION
query2_erroneous ="""SELECT 
TOP 3000
WHERE parallax < 1
source_id, ref_epoch, ra, dec, parallax
FROM gaiadr2.gaia_source
"""  The top query is wrong and have been replaced by this: query2_erroneous = """SELECT  TOP 3000
WHERE parallax < 1
source_id, ra, dec, pmra, pmdec, parallax
FROM gaiadr2.gaia_source
"""

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Yes 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

The open issue was to changed wrond query by the correct one

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
