### PR TITLE
Update 06-join.md

### DIFF
--- a/episodes/06-join.md
+++ b/episodes/06-join.md
@@ -171,11 +171,11 @@ in the Pan-STARRS catalog.
 To do that we will:
 
 1. Use the `JOIN` operator to look up each Pan-STARRS `obj_id` for the stars
-  we are interested in in the` panstarrs1_best_neighbour` table using the `source_id`s
+  we are interested in the `panstarrs1_best_neighbour` table using the `source_ids`
   that we have already identified.
 
 2. Use the `JOIN` operator again to look up the Pan-STARRS photometry for these stars
-  in the `panstarrs1_original_valid` table using the` obj_ids` we just identified.
+  in the `panstarrs1_original_valid` table using the `obj_ids` we just identified.
 
 Before we get to the `JOIN` operation, we will explore these tables.
 


### PR DESCRIPTION
Fix typo and missing space in  the following 2 lines: 

1- Use the JOIN operator to look up each Pan-STARRS obj_id for the stars we are interested in in thepanstarrs1_best_neighbour table using the source_ids that we have already identified.

2- Use the JOIN operator again to look up the Pan-STARRS photometry for these stars in the panstarrs1_original_valid table using theobj_ids we just identified.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
