### PR TITLE
Aligned the phi symbol in the text (φ) to the symbol used in the plots (ϕ)

### DIFF
--- a/episodes/02-coords.md
+++ b/episodes/02-coords.md
@@ -309,9 +309,9 @@ to GD-1:
 The axes of this figure are defined so the x-axis is aligned with the
 stars in GD-1, and the y-axis is perpendicular.
 
-- Along the x-axis (φ<sub>1</sub>) the figure extends from -100 to 20 degrees.
+- Along the x-axis ($\phi_1$) the figure extends from -100 to 20 degrees.
 
-- Along the y-axis (φ<sub>2</sub>) the figure extends from about -8 to 4 degrees.
+- Along the y-axis ($\phi_2$) the figure extends from about -8 to 4 degrees.
 
 Ideally, we would select all stars from this rectangle, but there are
 more than 10 million of them. This would be difficult to work with, and as
@@ -320,7 +320,7 @@ single query. While we are developing and testing code, it will be faster to wor
 with a smaller dataset.
 
 So we will start by selecting stars in a smaller rectangle near the
-center of GD-1, from -55 to -45 degrees φ<sub>1</sub> and -8 to 4 degrees φ<sub>2</sub>.
+center of GD-1, from -55 to -45 degrees $\phi_1$ and -8 to 4 degrees $\phi_2$.
 First we will learn how to represent these coordinates with Astropy.
 
 ## Transforming coordinates
@@ -392,7 +392,7 @@ which is "a Heliocentric spherical coordinate system defined by the
 orbit of the GD-1 stream". In this coordinate system, one axis is defined along
 the direction of the stream (the x-axis in Figure 1) and one axis is defined
 perpendicular to the direction of the stream (the y-axis in Figure 1).
-These are called the φ<sub>1</sub> and φ<sub>2</sub> coordinates, respectively.
+These are called the $\phi_1$ and $\phi_2$ coordinates, respectively.
 
 ```python
 from gala.coordinates import GD1Koposov10
@@ -457,7 +457,7 @@ rectangle that encompasses a small part of GD-1.
 This is easiest to define in GD-1 coordinates.
 
 The following variables define the boundaries of the rectangle in
-φ<sub>1</sub> and φ<sub>2</sub>.
+$\phi_1$ and $\phi_2$.
 
 ```python
 phi1_min = -55 * u.degree 
@@ -482,8 +482,8 @@ def make_rectangle(x1, x2, y1, y2):
     return xs, ys
 ```
 
-The return value is a tuple containing a list of coordinates in φ<sub>1</sub>
-followed by a list of coordinates in φ<sub>2</sub>.
+The return value is a tuple containing a list of coordinates in $\phi_1$
+followed by a list of coordinates in $\phi_2$.
 
 ```python
 phi1_rect, phi2_rect = make_rectangle(

--- a/episodes/03-transform.md
+++ b/episodes/03-transform.md
@@ -348,10 +348,10 @@ which is useful for two reasons:
 
 - By transforming the coordinates, we can identify stars that are
   likely to be in GD-1 by selecting stars near the centerline of the
-  stream, where φ<sub>2</sub> is close to 0.
+  stream, where $\phi_2$ is close to 0.
 
 - By transforming the proper motions, we can identify stars with
-  non-zero proper motion along the φ<sub>1</sub> axis, which are likely to be part of GD-1.
+  non-zero proper motion along the $\phi_1$ axis, which are likely to be part of GD-1.
 
 To do the transformation, we will put the results into a `SkyCoord`
 object.  In a previous episode, we created a `SkyCoord` object like


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This pull request replaces all occurrences of φ (eg. `φ<sub>1</sub>`) with ϕ (eg. `$\phi_1$`). This aligns the symbol for the longitude/latitude variables in the texts with the symbol used in the plots (see https://github.com/datacarpentry/astronomy-python/blob/68f4f890d13d03a0eefd419c1dd255ec609e2931/episodes/07-photo.md?plain=1#L615). The symbol is also used by the paper, the implementation of the GD1 coordinate reference system, "gala", is referring to (https://arxiv.org/pdf/0907.1085).

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
